### PR TITLE
feat(core): OpenAI-compatible pass-through sidecar (Issue #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -104,3 +104,40 @@ Revisions add a new entry that supersedes the old one rather than rewriting hist
   `tsconfig.json`, new `tsconfig.build.json`, `tsup.config.ts`, and
   `.github/workflows/ci.yml`. The HTTP framework decision originally
   pencilled in as ADR-0002 becomes ADR-0003 and lands with issue #2.
+
+## ADR-0003: HTTP framework choice
+
+- **Date:** 2026-04-18
+- **Status:** accepted
+- **Decision:** Use [`hono`](https://hono.dev) with `@hono/node-server` as
+  the HTTP layer for the sidecar's OpenAI-compatible server. Two new
+  runtime dependencies; runtime-dep budget (brief §8: under five) stays
+  comfortably under target.
+- **Rationale:** Hono is built on the Web Fetch API (`Request` /
+  `Response` / `ReadableStream`), which matches the shape of the
+  pass-through proxy almost exactly — the upstream client's request body
+  and headers map directly to a `fetch()` call against the downstream
+  target, and the downstream's streaming `Response.body` can be returned
+  unchanged. Hono ships with zero transitive dependencies of its own,
+  and `@hono/node-server` is a thin adapter onto `node:http`. Tests can
+  exercise the app via `app.fetch(request)` without binding a port,
+  which keeps the proxy test suite hermetic. The router primitive will
+  also absorb the additional endpoints expected from later issues
+  (`/v1/models`, header-based per-request overrides from issue #12,
+  health/readiness) without restructuring.
+- **Alternatives considered:**
+  - _Raw `node:http`._ Rejected. Workable for a single endpoint but
+    forces hand-rolled header copying, body buffering vs. piping
+    decisions, and streaming back-pressure handling that Hono gives for
+    free via the Fetch streaming APIs. The dependency saving (zero vs.
+    two) is real but small in absolute terms and the budget allows it.
+  - _`itty-router`._ Rejected. Comparable size, but less idiomatic on
+    Node for streaming bodies (designed primarily for edge runtimes
+    where body handling differs) and no first-class Node adapter
+    matching `@hono/node-server`.
+  - _`fastify` / `express`._ Rejected. Both pull in significantly more
+    surface area than the project's "minimal magic, minimal deps" stance
+    in brief §8 warrants for what is structurally a thin proxy.
+- **Related:** issue #2 (`feat/2-core-http-server`); the
+  `feat(core): …` commit on that branch introduces the dependencies and
+  the initial server / proxy modules.

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.15.0",
     "vitest": "^2.1.5"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.14",
+    "hono": "^4.12.14"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.14)
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -369,6 +376,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -865,6 +878,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1472,6 +1489,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1987,6 +2008,8 @@ snapshots:
   globals@14.0.0: {}
 
   has-flag@4.0.0: {}
+
+  hono@4.12.14: {}
 
   ignore@5.3.2: {}
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,70 @@
+// Environment-based config loader for issue #2.
+//
+// Deliberately separate from src/config/load.ts and src/config/schema.ts: those
+// are reserved for the Zod-schema-backed file-and-env loader from issue #11.
+// Pre-empting that work here would either duplicate the schema or force #11 to
+// rewrite this file. Once #11 lands, this loader can either be replaced or
+// kept as a thin shim that delegates to the schema-validated loader.
+
+import type { AppConfig } from '../types.js';
+
+/** Default sidecar port. Chosen to sit one above Ollama's 11434. */
+const DEFAULT_PORT = 11435;
+
+/**
+ * Read sidecar configuration from environment variables. Fails fast with
+ * an actionable error message (per brief §8: "Error messages include
+ * remediation hints") when required values are missing or malformed.
+ *
+ * Recognized variables:
+ * - `TURBO_DOWNSTREAM_BASE_URL` (required) — OpenAI-compatible base URL.
+ * - `TURBO_DOWNSTREAM_API_KEY` (optional) — bearer token forwarded only
+ *   when the client request lacks its own `Authorization` header.
+ * - `TURBO_PORT` (optional, default 11435) — TCP port to listen on.
+ */
+export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  const downstream = env.TURBO_DOWNSTREAM_BASE_URL?.trim();
+  if (!downstream) {
+    throw new Error(
+      'TURBO_DOWNSTREAM_BASE_URL is required. Set it to an OpenAI-compatible base URL ' +
+        '(e.g. http://localhost:11434/v1 for Ollama, https://api.openai.com/v1 for OpenAI). ' +
+        'The sidecar appends /chat/completions when forwarding.',
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(downstream);
+  } catch {
+    throw new Error(
+      `TURBO_DOWNSTREAM_BASE_URL is not a valid URL: ${JSON.stringify(downstream)}. ` +
+        'Expected a fully-qualified http(s) URL such as http://localhost:11434/v1.',
+    );
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `TURBO_DOWNSTREAM_BASE_URL must use http or https, got ${parsed.protocol.replace(':', '')}.`,
+    );
+  }
+
+  const portRaw = env.TURBO_PORT?.trim();
+  let port = DEFAULT_PORT;
+  if (portRaw !== undefined && portRaw !== '') {
+    const n = Number(portRaw);
+    if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+      throw new Error(
+        `TURBO_PORT must be an integer in 1..65535 if set, got ${JSON.stringify(portRaw)}.`,
+      );
+    }
+    port = n;
+  }
+
+  const apiKey = env.TURBO_DOWNSTREAM_API_KEY?.trim();
+  const downstreamBaseUrl = downstream.replace(/\/+$/, '');
+
+  return {
+    port,
+    downstreamBaseUrl,
+    ...(apiKey ? { downstreamApiKey: apiKey } : {}),
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,96 @@
-// TODO(issue #2): Forwarding to downstream target (any OpenAI-compatible
-// endpoint: ClawRouter, iblai-router, openmark-router, openrouter/auto,
-// or direct provider URLs).
+// Pass-through forwarder for OpenAI-compatible chat/completions requests.
+//
+// Issue #2 scope: forward the inbound request to a single configured
+// downstream target without any inspection or modification of the body, and
+// return the downstream response unchanged. No critic, no escalation, no
+// transparency annotations — those land in issues #3-#10.
 
-export {};
+import type { ProxyTarget } from './types.js';
+
+/**
+ * Hop-by-hop headers per RFC 7230 §6.1. These describe the connection
+ * between two specific HTTP peers and MUST NOT be forwarded by an
+ * intermediary; they are regenerated for each new connection by the runtime.
+ * `host` is added on top because Node's fetch implementation sets it from
+ * the target URL and a forwarded client `Host` would point at the wrong
+ * authority.
+ *
+ * Note: RFC 7230 §6.1 also permits a sender to list additional hop-by-hop
+ * header names inside the `Connection` header value. We do not parse
+ * `Connection`'s value here. Revisit if a real-world downstream relies on
+ * that mechanism.
+ */
+const HOP_BY_HOP_HEADERS: ReadonlySet<string> = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+function isHopByHop(name: string): boolean {
+  return HOP_BY_HOP_HEADERS.has(name.toLowerCase());
+}
+
+function copyEndToEndHeaders(source: Headers): Headers {
+  const out = new Headers();
+  for (const [name, value] of source) {
+    if (!isHopByHop(name)) out.set(name, value);
+  }
+  return out;
+}
+
+/**
+ * Forward an OpenAI chat/completions request to the configured downstream
+ * target without modification of the request body, and return the downstream
+ * response (status, end-to-end headers, body) unchanged. Streaming responses
+ * (`stream: true`) are passed through as a `ReadableStream` without
+ * intermediate buffering.
+ *
+ * Auth handling: the client's `Authorization` header is forwarded as-is when
+ * present; otherwise the configured `target.apiKey` is injected as
+ * `Authorization: Bearer <key>` so that the same sidecar can sit in front of
+ * a local Ollama (no auth) and a hosted provider (env-supplied key) without
+ * client changes.
+ */
+export async function forwardChatCompletion(
+  request: Request,
+  target: ProxyTarget,
+): Promise<Response> {
+  const headers = copyEndToEndHeaders(request.headers);
+
+  // Content-Length is end-to-end, not hop-by-hop, but Node's fetch
+  // implementation sets it itself from the body length. Keeping a
+  // client-supplied value risks a mismatch error from undici. The body bytes
+  // themselves are untouched; only the framing header is recomputed.
+  headers.delete('content-length');
+
+  if (!headers.has('authorization') && target.apiKey !== undefined) {
+    headers.set('authorization', `Bearer ${target.apiKey}`);
+  }
+
+  // Buffer the request body before forwarding. Chat/completions requests are
+  // small JSON bodies; the *response* is what may stream. Buffering keeps the
+  // forward call out of the half-duplex streaming-body code path and lets
+  // fetch set Content-Length correctly. Body bytes are passed byte-for-byte.
+  const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+  const body = hasBody ? await request.arrayBuffer() : undefined;
+
+  const url = `${target.baseUrl}/chat/completions`;
+
+  const downstream = await fetch(url, {
+    method: request.method,
+    headers,
+    ...(body !== undefined ? { body } : {}),
+  });
+
+  return new Response(downstream.body, {
+    status: downstream.status,
+    statusText: downstream.statusText,
+    headers: copyEndToEndHeaders(downstream.headers),
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,145 @@
-// TODO(issue #2): OpenAI-compatible HTTP server entry.
+// OpenAI-compatible HTTP server entry.
 //
-// Exposes a /v1 endpoint (chat/completions at minimum) that any OpenAI-compatible
-// client can point at. Delegates to proxy.ts for forwarding and to the
-// critic/escalation/transparency modules for the reactive layer.
+// Issue #2 scope: a minimal Hono app exposing POST /v1/chat/completions that
+// pass-through-forwards to a configured downstream target (see proxy.ts) and
+// emits one structured log line per request. Critic / escalation /
+// transparency hooks land in later issues.
 
-export {};
+import { fileURLToPath } from 'node:url';
+
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+
+import { loadEnvConfig } from './config/env.js';
+import { forwardChatCompletion } from './proxy.js';
+import type { AppConfig, ProxyTarget, RequestLogger } from './types.js';
+
+export interface AppDeps {
+  readonly proxyTarget: ProxyTarget;
+  /** Optional logger override; defaults to one JSON object per line on stderr. */
+  readonly logger?: RequestLogger;
+}
+
+const defaultLogger: RequestLogger = (entry) => {
+  process.stderr.write(`${JSON.stringify(entry)}\n`);
+};
+
+/**
+ * Build a Hono app wired against the given proxy target. Exported so tests
+ * can construct an app pointing at an in-process mock downstream without
+ * touching environment variables.
+ */
+export function createApp(deps: AppDeps): Hono {
+  const app = new Hono();
+  const log = deps.logger ?? defaultLogger;
+
+  app.post('/v1/chat/completions', async (c) => {
+    const start = Date.now();
+    let status = 0;
+    try {
+      const downstream = await forwardChatCompletion(c.req.raw, deps.proxyTarget);
+      status = downstream.status;
+      return downstream;
+    } catch (err) {
+      // The fetch call itself failed (downstream unreachable, DNS failure,
+      // connection reset before any HTTP response). Surface as 502 with a
+      // diagnostic body. HTTP-level errors from a reachable downstream go
+      // through the success branch above and are forwarded verbatim — the
+      // sidecar never invents its own error status when the downstream
+      // produced one.
+      status = 502;
+      const message = err instanceof Error ? err.message : 'unknown error';
+      return c.json(
+        {
+          error: {
+            message: `downstream request failed: ${message}`,
+            type: 'upstream_unreachable',
+          },
+        },
+        502,
+      );
+    } finally {
+      log({
+        ts: new Date().toISOString(),
+        method: c.req.method,
+        path: new URL(c.req.url).pathname,
+        status,
+        latency_ms: Date.now() - start,
+      });
+    }
+  });
+
+  return app;
+}
+
+/** Handle returned by {@link startServer} for graceful shutdown. */
+export interface RunningServer {
+  /** The address the server is listening on, for tests that bind port 0. */
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+/**
+ * Start the sidecar HTTP server on the configured port. Returns a handle
+ * with a `close()` for graceful shutdown.
+ */
+export function startServer(config: AppConfig = loadEnvConfig()): RunningServer {
+  const proxyTarget: ProxyTarget = {
+    baseUrl: config.downstreamBaseUrl,
+    ...(config.downstreamApiKey !== undefined ? { apiKey: config.downstreamApiKey } : {}),
+  };
+  const app = createApp({ proxyTarget });
+
+  const server = serve({
+    fetch: app.fetch,
+    port: config.port,
+  });
+
+  const address = server.address();
+  const boundPort = address !== null && typeof address === 'object' ? address.port : config.port;
+
+  return {
+    port: boundPort,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// Self-execution guard: running `node dist/server.js` boots the server;
+// importing the module from another file does not. Standard Node ESM
+// idiom for "is this the entry point".
+const isDirectRun = (() => {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  const config = loadEnvConfig();
+  const handle = startServer(config);
+  process.stderr.write(
+    `${JSON.stringify({
+      ts: new Date().toISOString(),
+      event: 'listen',
+      port: handle.port,
+      downstream: config.downstreamBaseUrl,
+    })}\n`,
+  );
+
+  const shutdown = (signal: string): void => {
+    process.stderr.write(
+      `${JSON.stringify({ ts: new Date().toISOString(), event: 'shutdown', signal })}\n`,
+    );
+    handle
+      .close()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,50 @@
-// TODO(issue #2): Shared types — OpenAI chat/completion shapes, critic verdict,
-// escalation decision, config surface, transparency event.
-//
-// Keep this file the single source of truth for cross-module types so that
-// critic/escalation/transparency don't end up with inconsistent shapes.
+// Shared type surface. The brief (§9) treats this file as the single source of
+// truth so that proxy / critic / escalation / transparency stay structurally
+// consistent. Issue #2 introduces the minimal surface needed for the
+// pass-through proxy; later issues extend it.
 
-export {};
+/**
+ * Effective configuration for a running sidecar process.
+ *
+ * Issue #2 reads this from environment variables (see {@link
+ * ../config/env.ts}). Issue #11 will introduce a Zod-validated config file
+ * shape and merge env / file / defaults; the resolved object satisfies this
+ * interface.
+ */
+export interface AppConfig {
+  /** TCP port the sidecar listens on. */
+  readonly port: number;
+  /**
+   * OpenAI-compatible base URL of the downstream target. Examples:
+   * `http://localhost:11434/v1` (Ollama), `https://api.openai.com/v1`,
+   * `https://api.anthropic.com/v1`. The proxy appends `/chat/completions`
+   * when forwarding; trailing slashes on the base URL are normalized away
+   * at load time.
+   */
+  readonly downstreamBaseUrl: string;
+  /**
+   * Optional bearer token to inject as `Authorization: Bearer <key>` when
+   * the upstream client did not supply its own `Authorization` header. Lets
+   * the same sidecar serve a local Ollama (no auth) and a hosted provider
+   * (env-supplied key) without client changes.
+   */
+  readonly downstreamApiKey?: string;
+}
+
+/** What the proxy needs to know about its forwarding target. */
+export interface ProxyTarget {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+}
+
+/** One log line per request. Emitted as a single JSON object on stderr. */
+export interface RequestLogEntry {
+  readonly ts: string;
+  readonly method: string;
+  readonly path: string;
+  /** HTTP status returned to the client. `0` if the request never produced one. */
+  readonly status: number;
+  readonly latency_ms: number;
+}
+
+export type RequestLogger = (entry: RequestLogEntry) => void;

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,9 +1,241 @@
-import { describe, it } from 'vitest';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type RunningServer } from '../src/server.js';
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  /** Base URL the sidecar should be configured to forward to. No trailing slash. */
+  readonly baseUrl: string;
+  /** Replace the per-request handler. The default returns 200 with `{}`. */
+  setHandler(handler: MockHandler): void;
+  /** Most recently received raw request body. */
+  lastBody(): Buffer | undefined;
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+  const bodies: Buffer[] = [];
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      bodies.push(body);
+      Promise.resolve(handler(req, res, body)).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end(`mock-error: ${String(err)}`);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}/v1`,
+    setHandler(h) {
+      handler = h;
+    },
+    lastBody() {
+      return bodies[bodies.length - 1];
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
 
 describe('proxy', () => {
-  it.todo('forwards a chat/completions request to the configured downstream (issue #2)');
-  it.todo('preserves request-id header on forward (issue #2)');
-  it.todo(
-    'streams the response back without buffering when the client asked for stream (issue #2)',
-  );
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    sidecar = startServer({
+      port: 0,
+      downstreamBaseUrl: mock.baseUrl,
+    });
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  it('forwards a non-streaming chat/completions request and returns the downstream response unchanged', async () => {
+    const downstreamBody = JSON.stringify({
+      id: 'chatcmpl-test-1',
+      object: 'chat.completion',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'hi' },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(downstreamBody);
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const text = await res.text();
+    expect(text).toBe(downstreamBody);
+  });
+
+  it('streams response chunks back to the client without buffering when stream: true', async () => {
+    // Strict streaming check: the mock sends frame 1, then awaits an external
+    // signal before sending frame 2. The test reads from the sidecar's
+    // response stream until it observes frame 1, only then resolves the
+    // signal. If anything in the chain (Hono, @hono/node-server, undici)
+    // buffered the whole response before forwarding, the client would never
+    // see frame 1, the test would never call releaseFrame2(), the mock would
+    // hang on the await, and the AbortSignal.timeout below would fail the
+    // test. Reading frame 1 strictly before frame 2 is sent is the property.
+    let releaseFrame2!: () => void;
+    const frame2Released = new Promise<void>((resolve) => {
+      releaseFrame2 = resolve;
+    });
+
+    mock.setHandler(async (_req, res, _body) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      });
+      res.write('data: {"id":"1","choices":[{"delta":{"content":"hel"}}]}\n\n');
+      // Block until the test confirms frame 1 reached the client.
+      await frame2Released;
+      res.write('data: {"id":"2","choices":[{"delta":{"content":"lo"}}]}\n\n');
+      res.write('data: [DONE]\n\n');
+      res.end();
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        stream: true,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+      signal: AbortSignal.timeout(7000),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toBeNull();
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // Chunks may not align with our SSE frame boundaries (TCP / undici can
+    // split or coalesce). Accumulate until we see the marker for frame 1.
+    let buf = '';
+    while (!buf.includes('"id":"1"')) {
+      const { value, done } = await reader.read();
+      if (done) {
+        throw new Error(`stream ended before frame 1 was observed; got: ${JSON.stringify(buf)}`);
+      }
+      buf += decoder.decode(value, { stream: true });
+    }
+
+    // Frame 1 is observably on the client side. Only now do we let the mock
+    // emit frame 2. Reaching this line proves the response was not buffered.
+    releaseFrame2();
+
+    while (!buf.includes('"id":"2"')) {
+      const { value, done } = await reader.read();
+      if (done) {
+        throw new Error(`stream ended before frame 2 was observed; got: ${JSON.stringify(buf)}`);
+      }
+      buf += decoder.decode(value, { stream: true });
+    }
+    while (!buf.includes('[DONE]')) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+
+    expect(buf).toContain('"id":"1"');
+    expect(buf).toContain('"id":"2"');
+    expect(buf).toContain('[DONE]');
+  }, 10_000);
+
+  it('forwards downstream HTTP errors verbatim instead of inventing its own', async () => {
+    const errorBody = JSON.stringify({
+      error: { message: 'internal model error', type: 'server_error' },
+    });
+    mock.setHandler((_req, res) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(errorBody);
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const text = await res.text();
+    expect(text).toBe(errorBody);
+  });
+
+  it('passes the request body through byte-for-byte without modification', async () => {
+    // Includes non-ASCII characters and a fixed property order so any
+    // round-trip through JSON.parse / JSON.stringify on the way through the
+    // sidecar would be visible as a diff.
+    const reqBody = JSON.stringify({
+      model: 'gpt-mini',
+      messages: [{ role: 'user', content: 'count from 1 to 5' }],
+      temperature: 0.7,
+      stream: false,
+      seed: 42,
+      meta: { lang: 'de-DE', emoji: 'ä-ö-ü-ß-€' },
+    });
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true}');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: reqBody,
+    });
+    expect(res.status).toBe(200);
+
+    const received = mock.lastBody();
+    expect(received).toBeDefined();
+    expect(received!.equals(Buffer.from(reqBody, 'utf-8'))).toBe(true);
+  });
 });


### PR DESCRIPTION
Implements Issue #2 from the project backlog: a minimal, OpenAI-compatible HTTP sidecar that forwards requests 1:1 to a configured downstream target. Establishes the surface area for later critic, escalation, and transparency work (issues #3–#10).

## What landed

- \`POST /v1/chat/completions\` forwards request body and headers verbatim to \`\${TURBO_DOWNSTREAM_BASE_URL}/chat/completions\`, streaming-compatible
- Hop-by-hop headers filtered exactly per RFC 7230 (see \`HOP_BY_HOP_HEADERS\` in \`src/proxy.ts\`)
- Fail-fast startup when \`TURBO_DOWNSTREAM_BASE_URL\` is missing; \`502\` only when downstream is actually unreachable
- Structured single-line JSON logging to stderr: \`{ ts, method, path, status, latency_ms }\`
- Env loader lives in \`src/config/env.ts\` (deliberately separate from \`src/config/load.ts\`, which is reserved for the Zod-based config work in Issue #11)

## Framework choice

Hono + \`@hono/node-server\`, documented in \`docs/DECISIONS.md\` as **ADR-0003**. Web Fetch API semantics make pass-through + streaming trivial; \`app.request()\` enables port-free tests. Runtime deps: 2 of the 5-dep budget used.

## Tests

\`test/proxy.test.ts\` now covers:
1. Non-streaming pass-through (body identity)
2. Streaming pass-through (strict: frame 1 must reach client before mock sends frame 2)
3. Error pass-through (downstream 500 → sidecar 500 with same body)
4. Request body byte-integrity

In-process \`node:http\` mock instead of msw/nock — exercises the real fetch round-trip, saves a dev dep.

## Smoke test (all green on Node 22)

\`\`\`
pnpm lint         # 0 errors
pnpm format:check # clean
pnpm typecheck    # clean under strict + exactOptionalPropertyTypes + noUncheckedIndexedAccess
pnpm test         # 5 passed, 14 todo (todos belong to later issues)
pnpm build        # dist/server.js 5.25 KB + dist/server.d.ts 2.53 KB
\`\`\`

## Deliberately out of scope (deferred to later issues)

- Critic (hard-signal + LLM), issues #3–#5
- Escalation strategies (ladder / max / chorus), issues #6–#8
- Transparency layer (banner / card / silent), issues #9–#10
- Zod-based config validation, issue #11
- Per-request override header \`X-Turbocharger-Mode\`, issue #12

## Commits

- \`docs: add ADR-0003 for HTTP framework choice\`
- \`feat(core): add hono-based OpenAI-compatible pass-through server\`
- \`test(proxy): cover non-streaming, streaming, error passthrough, and body integrity\`

Merge strategy recommendation: **Rebase and merge** to preserve the three-commit structure in \`main\` history.