### PR TITLE
feat(critic): hard-signal detection (#3, ADR-0008)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -319,3 +319,58 @@ Revisions add a new entry that supersedes the old one rather than rewriting hist
   `transparency:audit-log`. Audit retention enforcement
   (automatic cleanup after N days) is deferred to post-MVP; v0.1 ships
   with manual cleanup guidance in the docs.
+
+## ADR-0008: Syntax-error detection scope limited to JSON for v0.1
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** The `syntax_error` hard-signal detector (one of the
+  six categories introduced for ADR-0006) checks only JSON code fences
+  in v0.1. Blocks explicitly tagged `json` that fail `JSON.parse` emit
+  a signal at confidence `0.85`; blocks that parse cleanly, and fences
+  tagged with any other language (or with no tag at all), emit
+  nothing. Multi-language syntax validation (JavaScript/TypeScript,
+  Python, shell, SQL, etc.) is deferred to a post-MVP follow-up issue,
+  `critic:code-syntax`.
+- **Rationale:** `PROJECT_BRIEF.md` §4 calls out "syntax errors in
+  code outputs" as a hard-signal category, but does not scope _which_
+  languages. A useful multi-language check requires either a real
+  compiler/interpreter per language (pulls in heavy runtime
+  dependencies, often with native bindings, which violates the
+  runtime-dep budget in brief §8) or a tolerant parser that is likely
+  to over-fire on valid code it happens not to recognize. Neither fits
+  the "minimal magic, minimal deps" stance in the brief, and
+  over-firing specifically undermines ADR-0006 — the noisy-OR
+  aggregator depends on each detector having a low false-positive rate
+  at its declared confidence, because false fires from one detector
+  can pull the aggregate across the threshold on their own. JSON sits
+  at the opposite end of that trade: `JSON.parse` is in the runtime
+  already, is deterministic, and has a near-zero false-positive rate
+  when the fence is explicitly tagged `json`. In real-world LLM
+  traffic, structured JSON outputs (tool calls, form responses, config
+  blocks) are frequent, and a parse failure there is a clean
+  inadequacy signal.
+- **Alternatives considered:**
+  - _Full JavaScript/TypeScript validation via the `typescript`
+    package._ Rejected for v0.1. The TypeScript compiler is tolerant
+    by design — it parses many constructs that fail at runtime and
+    mis-reports many that succeed. Distinguishing true syntax errors
+    from resolution errors (e.g. `TS2307 "cannot find module"`) adds
+    significant maintenance surface. Worth doing as its own
+    `critic:code-syntax` issue with a dedicated config key; not worth
+    squeezing into #3.
+  - _Drop the `syntax_error` category from v0.1 entirely._ Rejected:
+    JSON parse-checks deliver genuine value for structured LLM output
+    at roughly fifteen lines of code and zero extra dependencies.
+    Losing that would be strictly worse for the same cost.
+  - _Multi-language via abstract-syntax-tree libraries (e.g.
+    `tree-sitter`)._ Rejected for v0.1. `tree-sitter` pulls in native
+    grammar bindings per language, which violates both the runtime-dep
+    budget and the implicit zero-native-dep preference in the brief.
+- **Related:** issue #3 (`critic:hard-signals`), in which the detector
+  lands. Post-MVP follow-up `critic:code-syntax` tracks full
+  multi-language coverage. The detector's `category` is kept as the
+  broader `syntax_error` (not `json_syntax_error`) so that the
+  transparency layer (ADR-0007) and the audit log need no changes
+  when the multi-language version lands; new languages extend the
+  detector, not the type surface.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "check": "pnpm format && pnpm lint:fix && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build",
+    "check:ci": "pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/critic/hard-signals.ts
+++ b/src/critic/hard-signals.ts
@@ -1,9 +1,324 @@
-// TODO(issue #3): Deterministic, zero-cost adequacy checks.
-// - Refusal patterns (locale-aware)
-// - Tool-call errors
-// - Syntax errors in code outputs (code-related requests only)
-// - Context-limit truncations (finish_reason: "length" without natural close)
-// - Repetition loops (n-gram repeat over threshold)
-// - Empty or suspiciously short outputs
+// Hard-signal detectors: deterministic, zero-cost adequacy checks that emit
+// probabilistic {@link Signal}s per ADR-0006. The orchestrator (issue #5)
+// aggregates signals from all enabled detectors via noisy-OR and compares
+// the aggregate against a threshold to decide escalation.
+//
+// Each detector is a pure function. A detector returns `null` when it finds
+// no evidence, or a {@link Signal} with a confidence score that reflects
+// how strongly it believes the response is inadequate.
+//
+// Scope notes:
+//   - Syntax-error checks cover JSON code fences only, per ADR-0008.
+//     Multi-language syntax validation (JS/TS/Python/...) lands in a
+//     post-MVP issue.
+//
+// Intentionally NOT in this file:
+//   - Aggregation / threshold logic: issue #5 (ADR-0006).
+//   - Per-rule disable flags from config: issue #11 (config schema).
+//   - Weight application: issue #5.
 
-export {};
+import type { DetectorInput, HardSignalDetector, Signal } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Refusal
+// ---------------------------------------------------------------------------
+
+interface RefusalPattern {
+  readonly pattern: RegExp;
+  readonly confidence: number;
+}
+
+/**
+ * Locale-keyed refusal patterns. Confidence levels:
+ *   0.95 — explicit, unambiguous refusal.
+ *   0.70 — boilerplate AI-disclaimer preamble often preceding a refusal.
+ *   0.40 — soft hedging that sometimes but not always precedes refusal.
+ *
+ * Patterns are case-insensitive.
+ */
+const REFUSAL_PATTERNS: Readonly<Record<string, readonly RefusalPattern[]>> = {
+  en: [
+    {
+      pattern: /\bI\s+(?:can(?:not|'t)|am\s+unable\s+to|won't)\s+(?:help|assist|provide|do)\b/i,
+      confidence: 0.95,
+    },
+    {
+      pattern:
+        /\b(?:sorry|unfortunately)[,.]\s*(?:but\s+)?I\s+(?:can(?:not|'t)|am\s+unable\s+to)\b/i,
+      confidence: 0.95,
+    },
+    { pattern: /\bAs\s+an\s+AI\s+(?:language\s+)?(?:model|assistant)[,.]/i, confidence: 0.7 },
+    { pattern: /\bI\s+(?:must|should|would)\s+(?:caution|advise|warn|note)\b/i, confidence: 0.4 },
+    { pattern: /\bI\s+have\s+concerns\s+about\b/i, confidence: 0.4 },
+  ],
+  de: [
+    {
+      pattern: /\b(?:ich\s+kann\s+(?:dir|Ihnen|dabei)\s+nicht\s+helfen|ich\s+bin\s+nicht\s+in\s+der\s+Lage)\b/i,
+      confidence: 0.95,
+    },
+    {
+      pattern: /\b(?:leider|entschuldigung)[,.]\s*(?:aber\s+)?(?:ich\s+kann|das\s+kann\s+ich\s+nicht)\b/i,
+      confidence: 0.95,
+    },
+    { pattern: /\bAls\s+(?:KI|K\.I\.|ein\s+KI-(?:Assistent|Modell))[,.]/i, confidence: 0.7 },
+    {
+      pattern: /\bich\s+(?:muss|sollte|möchte)\s+(?:darauf\s+hinweisen|anmerken|warnen)\b/i,
+      confidence: 0.4,
+    },
+  ],
+};
+
+const DEFAULT_LOCALE = 'en';
+
+export const refusalDetector: HardSignalDetector = (input) => {
+  const locale = input.locale ?? DEFAULT_LOCALE;
+  const primary = REFUSAL_PATTERNS[locale] ?? REFUSAL_PATTERNS[DEFAULT_LOCALE] ?? [];
+  // Also try English patterns as a fallback — non-English interactions
+  // frequently surface English refusal phrasing from providers whose
+  // system prompts lean toward English.
+  const fallback = locale === DEFAULT_LOCALE ? [] : (REFUSAL_PATTERNS[DEFAULT_LOCALE] ?? []);
+  const candidates = [...primary, ...fallback];
+
+  let best: RefusalPattern | null = null;
+  for (const candidate of candidates) {
+    if (candidate.pattern.test(input.response)) {
+      if (best === null || candidate.confidence > best.confidence) {
+        best = candidate;
+      }
+    }
+  }
+
+  if (best === null) return null;
+  return {
+    category: 'refusal',
+    confidence: best.confidence,
+    reason: `refusal phrase matched: /${best.pattern.source.slice(0, 60)}/`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Truncation
+// ---------------------------------------------------------------------------
+
+/**
+ * Likely truncation when the provider signaled `finish_reason: "length"`
+ * AND the text does not end with a natural sentence terminator.
+ * Terminator detection is heuristic — it permits trailing whitespace and
+ * closing quotes/brackets, and covers English, German, and CJK punctuation.
+ */
+export const truncationDetector: HardSignalDetector = (input) => {
+  if (input.finishReason !== 'length') return null;
+
+  const trimmed = input.response.replace(/[\s"')\]}]+$/u, '');
+  if (trimmed.length === 0) {
+    // Empty-after-trim is the {@link emptyDetector}'s territory; do not
+    // double-fire here.
+    return null;
+  }
+  const lastChar = trimmed[trimmed.length - 1];
+  const endsNaturally = lastChar !== undefined && /[.!?。！？]/u.test(lastChar);
+
+  const confidence = endsNaturally ? 0.6 : 0.9;
+  return {
+    category: 'truncation',
+    confidence,
+    reason: endsNaturally
+      ? 'finish_reason=length with sentence terminator (ambiguous)'
+      : 'finish_reason=length and text ends mid-thought',
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Repetition
+// ---------------------------------------------------------------------------
+
+const NGRAM_SIZE = 4;
+const MIN_REPEAT_COUNT = 3;
+const MIN_TOKENS = 20;
+
+/**
+ * N-gram based repetition detector. Fires only when:
+ *   - the response has at least {@link MIN_TOKENS} tokens (shorter
+ *     responses are the empty/short detector's territory), AND
+ *   - the most frequent {@link NGRAM_SIZE}-gram appears at least
+ *     {@link MIN_REPEAT_COUNT} times.
+ *
+ * Confidence scales with the *share* of the response that the most
+ * frequent n-gram occupies (doubled and clamped to [0.4, 0.95] so that
+ * the minimum repeat count registers meaningfully but this heuristic
+ * never claims certainty on its own).
+ */
+export const repetitionDetector: HardSignalDetector = (input) => {
+  const tokens = input.response.toLowerCase().match(/\S+/g) ?? [];
+  if (tokens.length < MIN_TOKENS) return null;
+
+  const counts = new Map<string, number>();
+  for (let i = 0; i + NGRAM_SIZE <= tokens.length; i++) {
+    const gram = tokens.slice(i, i + NGRAM_SIZE).join(' ');
+    counts.set(gram, (counts.get(gram) ?? 0) + 1);
+  }
+
+  let maxCount = 0;
+  let maxGram = '';
+  for (const [gram, count] of counts) {
+    if (count > maxCount) {
+      maxCount = count;
+      maxGram = gram;
+    }
+  }
+
+  if (maxCount < MIN_REPEAT_COUNT) return null;
+
+  const totalGrams = tokens.length - NGRAM_SIZE + 1;
+  const share = maxCount / totalGrams;
+  const confidence = Math.min(0.95, Math.max(0.4, share * 2));
+
+  return {
+    category: 'repetition',
+    confidence,
+    reason: `${maxCount}× repeated ${NGRAM_SIZE}-gram: "${maxGram.slice(0, 40)}"`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Empty / short
+// ---------------------------------------------------------------------------
+
+/**
+ * Flags responses that are suspiciously short relative to the user's
+ * prompt. Comparison is on character length rather than tokens — good
+ * enough for coarse triage, and it sidesteps a tokenizer dependency.
+ */
+export const emptyDetector: HardSignalDetector = (input) => {
+  const responseLen = input.response.trim().length;
+  const promptLen = input.userPrompt.trim().length;
+
+  if (responseLen === 0) {
+    return { category: 'empty', confidence: 0.95, reason: 'empty response' };
+  }
+  if (responseLen < 20 && promptLen >= 50) {
+    return {
+      category: 'empty',
+      confidence: 0.9,
+      reason: `response too short (${responseLen} chars) for prompt (${promptLen} chars)`,
+    };
+  }
+  if (responseLen < 50 && promptLen >= 200) {
+    return {
+      category: 'empty',
+      confidence: 0.6,
+      reason: `response short (${responseLen} chars) relative to prompt (${promptLen} chars)`,
+    };
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Tool error
+// ---------------------------------------------------------------------------
+
+/**
+ * Flags tool-call failures that surfaced in the response body. Structured
+ * tool-call errors at the HTTP level are handled by the orchestrator
+ * (issue #5); this detector catches error/exception markers that leaked
+ * through into the assistant's textual output.
+ *
+ * The pattern requires the marker at the start of a line to avoid
+ * matching the word "error" used as prose ("the most common error is
+ * thinking…").
+ */
+const TOOL_ERROR_PATTERN =
+  /(?:^|\n)\s*(?:Error|Exception|Traceback|TypeError|ValueError|SyntaxError|RuntimeError)\b[:\s]/;
+
+export const toolErrorDetector: HardSignalDetector = (input) => {
+  if (TOOL_ERROR_PATTERN.test(input.response)) {
+    return {
+      category: 'tool_error',
+      confidence: 0.9,
+      reason: 'error/exception marker at line start in response',
+    };
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Syntax error — JSON only (ADR-0008)
+// ---------------------------------------------------------------------------
+
+/**
+ * Flags responses that contain a fenced code block explicitly tagged as
+ * JSON whose contents do not parse. Untagged fences are skipped because
+ * the language is ambiguous and false positives would dominate.
+ *
+ * Scope is limited to JSON in v0.1 per ADR-0008; multi-language syntax
+ * checking is deferred to a post-MVP issue (`critic:code-syntax`). The
+ * `syntax_error` category is kept broad so that consumers
+ * (transparency layer, audit log) need no changes when additional
+ * languages are added.
+ */
+const JSON_FENCE = /```json\s*\n([\s\S]*?)\n\s*```/g;
+
+export const syntaxErrorDetector: HardSignalDetector = (input) => {
+  // Reset lastIndex in case the shared regex was used by something earlier.
+  JSON_FENCE.lastIndex = 0;
+
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = JSON_FENCE.exec(input.response)) !== null) {
+    if (match[1] !== undefined) blocks.push(match[1]);
+  }
+
+  if (blocks.length === 0) return null;
+
+  const failures: string[] = [];
+  for (const block of blocks) {
+    try {
+      JSON.parse(block);
+    } catch (err) {
+      failures.push(err instanceof Error ? err.message : 'parse failure');
+    }
+  }
+
+  if (failures.length === 0) return null;
+  return {
+    category: 'syntax_error',
+    confidence: 0.85,
+    reason: `${failures.length} of ${blocks.length} JSON block(s) failed to parse: ${failures[0] ?? ''}`,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Composite
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical detector list. Exported so tests and the orchestrator
+ * (issue #5) can iterate without importing each detector by name, and
+ * so the order of emitted signals is deterministic.
+ */
+export const HARD_SIGNAL_DETECTORS: readonly HardSignalDetector[] = [
+  refusalDetector,
+  truncationDetector,
+  repetitionDetector,
+  emptyDetector,
+  toolErrorDetector,
+  syntaxErrorDetector,
+];
+
+/**
+ * Run every hard-signal detector and return the non-null results in the
+ * canonical order defined by {@link HARD_SIGNAL_DETECTORS}. The returned
+ * list may be empty.
+ *
+ * This function deliberately does not apply weights, does not compare
+ * against any threshold, and does not express a pass/fail verdict — those
+ * concerns belong to the orchestrator in issue #5, following ADR-0006.
+ */
+export function collectHardSignals(input: DetectorInput): readonly Signal[] {
+  const signals: Signal[] = [];
+  for (const detector of HARD_SIGNAL_DETECTORS) {
+    const signal = detector(input);
+    if (signal !== null) signals.push(signal);
+  }
+  return signals;
+}

--- a/src/critic/hard-signals.ts
+++ b/src/critic/hard-signals.ts
@@ -53,11 +53,13 @@ const REFUSAL_PATTERNS: Readonly<Record<string, readonly RefusalPattern[]>> = {
   ],
   de: [
     {
-      pattern: /\b(?:ich\s+kann\s+(?:dir|Ihnen|dabei)\s+nicht\s+helfen|ich\s+bin\s+nicht\s+in\s+der\s+Lage)\b/i,
+      pattern:
+        /\b(?:ich\s+kann\s+(?:dir|Ihnen|dabei)\s+nicht\s+helfen|ich\s+bin\s+nicht\s+in\s+der\s+Lage)\b/i,
       confidence: 0.95,
     },
     {
-      pattern: /\b(?:leider|entschuldigung)[,.]\s*(?:aber\s+)?(?:ich\s+kann|das\s+kann\s+ich\s+nicht)\b/i,
+      pattern:
+        /\b(?:leider|entschuldigung)[,.]\s*(?:aber\s+)?(?:ich\s+kann|das\s+kann\s+ich\s+nicht)\b/i,
       confidence: 0.95,
     },
     { pattern: /\bAls\s+(?:KI|K\.I\.|ein\s+KI-(?:Assistent|Modell))[,.]/i, confidence: 0.7 },

--- a/src/critic/index.ts
+++ b/src/critic/index.ts
@@ -1,6 +1,23 @@
-// TODO(issue #5): Orchestrator for the hybrid cascade critic.
-// Runs hard-signals first; falls through to llm-critic only when hard-signals
-// return "no clear failure" AND config allows LLM-critic AND budget is not
-// exceeded. Emits a verdict: "pass" | "fail" with reason + confidence.
+// Critic module barrel.
+//
+// Issue #3 scope: re-exports the hard-signal detection surface
+// (see {@link ./hard-signals.ts}). The noisy-OR aggregator, weight
+// application, and verdict/threshold decision live in a future file
+// in this directory, added when issue #5 lands.
+//
+// Until then, callers get only the detection primitives. The
+// orchestrator's interface (cascade strategy, threshold comparison,
+// LLM-critic gating, cost ceiling) is deliberately not committed yet,
+// because its exact shape is driven by ADR-0006 (aggregation) and
+// the config schema from issue #11.
 
-export {};
+export {
+  collectHardSignals,
+  emptyDetector,
+  HARD_SIGNAL_DETECTORS,
+  refusalDetector,
+  repetitionDetector,
+  syntaxErrorDetector,
+  toolErrorDetector,
+  truncationDetector,
+} from './hard-signals.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 // Shared type surface. The brief (§9) treats this file as the single source of
 // truth so that proxy / critic / escalation / transparency stay structurally
 // consistent. Issue #2 introduces the minimal surface needed for the
-// pass-through proxy; later issues extend it.
+// pass-through proxy; issue #3 adds the hard-signal detection surface;
+// later issues extend further.
 
 /**
  * Effective configuration for a running sidecar process.
@@ -48,3 +49,65 @@ export interface RequestLogEntry {
 }
 
 export type RequestLogger = (entry: RequestLogEntry) => void;
+
+// ---------------------------------------------------------------------------
+// Critic — hard-signal detection (issue #3)
+// ---------------------------------------------------------------------------
+
+/**
+ * One piece of evidence that a response may be inadequate. Detectors in
+ * {@link ../critic/hard-signals.ts} emit these; the orchestrator
+ * (issue #5) aggregates them via noisy-OR per ADR-0006 and compares the
+ * result to a configurable threshold.
+ */
+export interface Signal {
+  readonly category: SignalCategory;
+  /**
+   * Continuous confidence in `[0, 1]`. `0` means no evidence, `1` means
+   * certainty. Detectors use intermediate values to express "weak but
+   * present" evidence that would be lost by a boolean fire/no-fire output
+   * — exactly the case ADR-0006 cites as the motivation for the noisy-OR
+   * aggregator.
+   */
+  readonly confidence: number;
+  /** Short human-readable reason, suitable for transparency banner / card. */
+  readonly reason: string;
+}
+
+export type SignalCategory =
+  | 'refusal'
+  | 'truncation'
+  | 'repetition'
+  | 'empty'
+  | 'tool_error'
+  | 'syntax_error';
+
+/**
+ * Input bundle passed to every hard-signal detector. A detector reads
+ * whichever fields it needs and returns a {@link Signal} or `null`.
+ *
+ * Kept deliberately small: the orchestrator (issue #5) may enrich it
+ * later with per-request metadata (e.g. user-specified locale override,
+ * trace id for the audit log from ADR-0007), but a detector should never
+ * need provider-specific fields.
+ */
+export interface DetectorInput {
+  /** The assembled response text content as the client would see it. */
+  readonly response: string;
+  /** The user's most recent message, for context-dependent checks. */
+  readonly userPrompt: string;
+  /**
+   * OpenAI `finish_reason` from the upstream response, when the provider
+   * supplied one. Common values: `"stop"`, `"length"`, `"tool_calls"`,
+   * `"content_filter"`.
+   */
+  readonly finishReason?: string;
+  /**
+   * BCP-47 locale hint used for locale-aware pattern matching (refusal
+   * phrases, sentence terminators). Defaults to `"en"` when absent.
+   */
+  readonly locale?: string;
+}
+
+/** Signature every hard-signal detector must satisfy. */
+export type HardSignalDetector = (input: DetectorInput) => Signal | null;

--- a/test/hard-signals.test.ts
+++ b/test/hard-signals.test.ts
@@ -71,7 +71,8 @@ describe('refusalDetector', () => {
   it('flags soft hedging at low confidence', () => {
     const signal = refusalDetector(
       makeInput({
-        response: 'I would advise caution when interpreting these numbers because the data has gaps.',
+        response:
+          'I would advise caution when interpreting these numbers because the data has gaps.',
       }),
     );
     expect(signal).not.toBeNull();
@@ -355,7 +356,7 @@ describe('collectHardSignals', () => {
     // Refusal fires at index 0 in HARD_SIGNAL_DETECTORS; syntax_error fires at
     // index 5. If both are present, refusal must appear first in the result.
     const input = makeInput({
-      response: "I cannot help with that.\n```json\n{broken}\n```",
+      response: 'I cannot help with that.\n```json\n{broken}\n```',
       userPrompt:
         'Please explain how to implement a JSON parser in Python and include an example payload.',
     });

--- a/test/hard-signals.test.ts
+++ b/test/hard-signals.test.ts
@@ -1,11 +1,375 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-describe('critic: hard-signals', () => {
-  it.todo('flags English refusal patterns (issue #3)');
-  it.todo('flags locale-variant refusal patterns (issue #3)');
-  it.todo('flags finish_reason: "length" without natural close (issue #3)');
-  it.todo('flags repetition loops above threshold (issue #3)');
-  it.todo('flags empty / suspiciously short outputs on non-trivial queries (issue #3)');
-  it.todo('flags syntax errors only when the request was code-related (issue #3)');
-  it.todo('does NOT flag otherwise-adequate answers (issue #3)');
+import {
+  collectHardSignals,
+  emptyDetector,
+  HARD_SIGNAL_DETECTORS,
+  refusalDetector,
+  repetitionDetector,
+  syntaxErrorDetector,
+  toolErrorDetector,
+  truncationDetector,
+} from '../src/critic/index.js';
+import type { DetectorInput, Signal } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a DetectorInput with sensible defaults; spread overrides to tune
+ * specific cases. The default user prompt is intentionally long enough
+ * that the empty/short detector stays silent unless a test targets it
+ * explicitly.
+ */
+function makeInput(overrides: Partial<DetectorInput> = {}): DetectorInput {
+  const base: DetectorInput = {
+    response: 'Default response text with enough content to not trip the empty detector.',
+    userPrompt:
+      'Please write a short friendly greeting. The prompt is deliberately long so that ' +
+      'the empty-response detector stays silent unless a test targets it.',
+  };
+  return { ...base, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// refusalDetector
+// ---------------------------------------------------------------------------
+
+describe('refusalDetector', () => {
+  it('flags explicit English refusal with high confidence', () => {
+    const signal = refusalDetector(
+      makeInput({ response: "I'm sorry, but I cannot help with that request." }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.category).toBe('refusal');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('flags explicit German refusal with high confidence', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'Leider, aber ich kann dir nicht helfen, das ist nicht möglich.',
+        locale: 'de',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.category).toBe('refusal');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('flags AI-disclaimer boilerplate at medium confidence when no stronger match is present', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'As an AI language model, here is some general guidance on the topic.',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.confidence).toBeCloseTo(0.7, 1);
+  });
+
+  it('flags soft hedging at low confidence', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'I would advise caution when interpreting these numbers because the data has gaps.',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.confidence).toBeCloseTo(0.4, 1);
+  });
+
+  it('returns null for an adequate response', () => {
+    const signal = refusalDetector(
+      makeInput({ response: 'Here is a helpful answer to your question with concrete details.' }),
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('falls back to English patterns when the hinted locale is unknown', () => {
+    const signal = refusalDetector(
+      makeInput({ response: "I'm sorry, but I cannot help with that.", locale: 'fr' }),
+    );
+    expect(signal).not.toBeNull();
+  });
+
+  it('reports the highest-confidence match when multiple patterns fire', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response:
+          "As an AI language model, I have concerns about this. I'm sorry, but I cannot help.",
+      }),
+    );
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.95);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// truncationDetector
+// ---------------------------------------------------------------------------
+
+describe('truncationDetector', () => {
+  it('returns null when finish_reason is not "length"', () => {
+    const signal = truncationDetector(
+      makeInput({ response: 'Complete answer here.', finishReason: 'stop' }),
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('high confidence when text ends mid-thought', () => {
+    const signal = truncationDetector(
+      makeInput({ response: 'The capital of France is Par', finishReason: 'length' }),
+    );
+    expect(signal?.category).toBe('truncation');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('medium confidence when text ends with a natural terminator', () => {
+    const signal = truncationDetector(
+      makeInput({
+        response: 'The capital of France is Paris. It is a large city.',
+        finishReason: 'length',
+      }),
+    );
+    expect(signal?.category).toBe('truncation');
+    expect(signal?.confidence).toBeLessThan(0.85);
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('recognises German sentence terminators', () => {
+    const signal = truncationDetector(
+      makeInput({
+        response: 'Die Hauptstadt Frankreichs ist Paris.',
+        finishReason: 'length',
+        locale: 'de',
+      }),
+    );
+    expect(signal?.confidence).toBeLessThan(0.85);
+  });
+
+  it('ignores trailing whitespace and closing quotes when checking terminator', () => {
+    const signal = truncationDetector(
+      makeInput({ response: '"The answer is yes."   ', finishReason: 'length' }),
+    );
+    expect(signal?.confidence).toBeLessThan(0.85);
+  });
+
+  it('returns null when length=finish_reason but response is empty (emptyDetector handles that)', () => {
+    const signal = truncationDetector(makeInput({ response: '', finishReason: 'length' }));
+    expect(signal).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repetitionDetector
+// ---------------------------------------------------------------------------
+
+describe('repetitionDetector', () => {
+  it('returns null for short responses (below MIN_TOKENS)', () => {
+    const signal = repetitionDetector(
+      makeInput({ response: 'Hello world, hello world, hello world.' }),
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('returns null for responses without sufficient repetition', () => {
+    const response =
+      'This response has enough tokens to clear the minimum threshold but ' +
+      'does not contain any repeated four-word sequences anywhere within its ' +
+      'otherwise perfectly reasonable textual content that continues onwards.';
+    expect(repetitionDetector(makeInput({ response }))).toBeNull();
+  });
+
+  it('flags clearly degenerate repetition loops', () => {
+    const phrase = 'the system is ready';
+    const response = Array.from({ length: 10 }, () => phrase).join(' ') + ' end of response.';
+    const signal = repetitionDetector(makeInput({ response }));
+    expect(signal?.category).toBe('repetition');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.4);
+  });
+
+  it('assigns higher confidence when repetition dominates the text', () => {
+    const loopy = Array.from({ length: 20 }, () => 'ok ok ok ok').join(' ');
+    const sparse =
+      Array.from({ length: 3 }, () => 'same phrase repeats here').join(' ') +
+      ' ' +
+      'followed by a long stretch of unique and non-repeating text that fills the rest.';
+
+    const loopySignal = repetitionDetector(makeInput({ response: loopy }));
+    const sparseSignal = repetitionDetector(makeInput({ response: sparse }));
+
+    expect(loopySignal).not.toBeNull();
+    if (loopySignal !== null && sparseSignal !== null) {
+      expect(loopySignal.confidence).toBeGreaterThanOrEqual(sparseSignal.confidence);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emptyDetector
+// ---------------------------------------------------------------------------
+
+describe('emptyDetector', () => {
+  it('flags a fully empty response', () => {
+    const signal = emptyDetector(makeInput({ response: '' }));
+    expect(signal?.category).toBe('empty');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('flags a very short response to a non-trivial prompt', () => {
+    const signal = emptyDetector(
+      makeInput({
+        response: 'ok',
+        userPrompt:
+          'Please explain the key differences between TCP and UDP protocols in networking.',
+      }),
+    );
+    expect(signal?.category).toBe('empty');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('returns null when response is proportional to a short prompt', () => {
+    const signal = emptyDetector(
+      makeInput({ response: 'Here is a reasonable answer.', userPrompt: 'Short question?' }),
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('medium confidence for a short response to a long prompt', () => {
+    const signal = emptyDetector(
+      makeInput({
+        response: 'Yes, that is correct.',
+        userPrompt:
+          'Could you please provide a detailed overview of the historical development of ' +
+          'quantum mechanics, starting with the early work of Planck and Einstein, moving ' +
+          'through the Bohr model, and culminating in the formulation by Heisenberg, ' +
+          'Schrödinger, and Dirac? Please include the key experimental evidence that ' +
+          'supported each step of the way.',
+      }),
+    );
+    expect(signal?.category).toBe('empty');
+    expect(signal?.confidence).toBeCloseTo(0.6, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolErrorDetector
+// ---------------------------------------------------------------------------
+
+describe('toolErrorDetector', () => {
+  it('flags a Python-style traceback', () => {
+    const response = [
+      'I tried to run that for you but got:',
+      'Traceback (most recent call last):',
+      '  File "<stdin>", line 1, in <module>',
+      "TypeError: unsupported operand type(s) for +: 'int' and 'str'",
+    ].join('\n');
+    const signal = toolErrorDetector(makeInput({ response }));
+    expect(signal?.category).toBe('tool_error');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('flags a generic Error marker at line start', () => {
+    const signal = toolErrorDetector(
+      makeInput({ response: 'Let me try that:\nError: connection refused.' }),
+    );
+    expect(signal?.category).toBe('tool_error');
+  });
+
+  it('does not flag the word "error" used in prose', () => {
+    const signal = toolErrorDetector(
+      makeInput({
+        response:
+          'One common error when learning TypeScript is thinking it runs at runtime; it does not.',
+      }),
+    );
+    expect(signal).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syntaxErrorDetector — JSON only per ADR-0008
+// ---------------------------------------------------------------------------
+
+describe('syntaxErrorDetector', () => {
+  it('returns null when the response has no JSON fence', () => {
+    const signal = syntaxErrorDetector(
+      makeInput({ response: 'Here is a textual answer with no code fences at all.' }),
+    );
+    expect(signal).toBeNull();
+  });
+
+  it('returns null when every JSON fence parses cleanly', () => {
+    const response = 'Here you go:\n```json\n{"ok": true, "count": 42}\n```\nEnjoy!';
+    expect(syntaxErrorDetector(makeInput({ response }))).toBeNull();
+  });
+
+  it('flags a JSON fence that fails to parse', () => {
+    const response = 'Here you go:\n```json\n{"ok": true, "count": 42,}\n```';
+    const signal = syntaxErrorDetector(makeInput({ response }));
+    expect(signal?.category).toBe('syntax_error');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('ignores untagged fences even when their content is not JSON', () => {
+    const response = 'Here is some code:\n```\nnot valid json {\n```';
+    expect(syntaxErrorDetector(makeInput({ response }))).toBeNull();
+  });
+
+  it('reports the failure when any of several JSON blocks is malformed', () => {
+    const response = 'First:\n```json\n{"a":1}\n```\nSecond:\n```json\n{broken json}\n```';
+    const signal = syntaxErrorDetector(makeInput({ response }));
+    expect(signal).not.toBeNull();
+    expect(signal?.reason).toContain('1 of 2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectHardSignals — composition
+// ---------------------------------------------------------------------------
+
+describe('collectHardSignals', () => {
+  it('returns an empty list when the response is adequate', () => {
+    const signals = collectHardSignals(
+      makeInput({
+        response:
+          'Sure — here is a friendly greeting: "Hello, nice to meet you. How may I help you today?"',
+      }),
+    );
+    expect(signals).toEqual([]);
+  });
+
+  it('collects signals from multiple categories when several detectors fire', () => {
+    const input = makeInput({
+      response: "I'm sorry, but I cannot",
+      userPrompt:
+        'Please explain the Ship of Theseus paradox in three paragraphs with historical references.',
+      finishReason: 'length',
+    });
+    const signals = collectHardSignals(input);
+    const categories = new Set(signals.map((s: Signal) => s.category));
+    expect(categories.has('refusal')).toBe(true);
+    expect(categories.has('truncation')).toBe(true);
+  });
+
+  it('preserves the canonical detector order in its output', () => {
+    // Refusal fires at index 0 in HARD_SIGNAL_DETECTORS; syntax_error fires at
+    // index 5. If both are present, refusal must appear first in the result.
+    const input = makeInput({
+      response: "I cannot help with that.\n```json\n{broken}\n```",
+      userPrompt:
+        'Please explain how to implement a JSON parser in Python and include an example payload.',
+    });
+    const signals = collectHardSignals(input);
+    const refusalIdx = signals.findIndex((s: Signal) => s.category === 'refusal');
+    const syntaxIdx = signals.findIndex((s: Signal) => s.category === 'syntax_error');
+    expect(refusalIdx).toBeGreaterThanOrEqual(0);
+    expect(syntaxIdx).toBeGreaterThanOrEqual(0);
+    expect(refusalIdx).toBeLessThan(syntaxIdx);
+  });
+
+  it('exposes the expected number of detectors', () => {
+    // Sentinel: when a detector is added, this test reminds the author to
+    // update the SignalCategory union and the suites above.
+    expect(HARD_SIGNAL_DETECTORS).toHaveLength(6);
+  });
 });


### PR DESCRIPTION
Closes #3.

Implements the six hard-signal detectors from brief §4, adapted to the
continuous-confidence / noisy-OR regime introduced in ADR-0006: issue #3
emits `Signal`s, issue #5 will aggregate them.

## Commits

- **`feat(critic)`** — Adds `Signal`, `SignalCategory`, `DetectorInput`,
  and `HardSignalDetector` types to `src/types.ts`; the six detectors
  (refusal EN+DE with three confidence tiers, truncation, repetition,
  empty/short, tool error, syntax error) in `src/critic/hard-signals.ts`;
  and the `collectHardSignals` composer plus the barrel in
  `src/critic/index.ts`.
- **`test(critic)`** — 28 unit tests across seven suites (one per
  detector plus the composer), with EN + DE fixtures for refusal, CJK +
  German terminator coverage for truncation, and sentinel counts to
  notify future authors when the detector list changes.
- **`docs`** — Records ADR-0008: `syntax_error` detection is limited to
  JSON in v0.1; multi-language coverage deferred to a post-MVP
  `critic:code-syntax` follow-up. The `Signal.category` value stays as
  `'syntax_error'` (not `'json_syntax_error'`) so the transparency and
  audit layers from ADR-0007 need no migration when that expansion lands.
- **`chore`** — Introduces `pnpm check` as the standard local
  entrypoint (format + lint-fix + read-only gates) and `pnpm check:ci`
  for strict read-only CI. Motivation: issues #2 and #3 both produced
  prettier-drift fixup commits because patches were prepared without
  Prettier available; `pnpm check` eliminates that pattern.

## Verification

`pnpm check` green locally: 38 passed / 7 todo, no format or lint
warnings, typecheck clean, build succeeds.

## Explicitly not in this PR

- Noisy-OR aggregation and the escalation threshold — issue #5.
- Per-rule disable flags and category weights — issue #11 (config).
- Weight application and verdict emission — issue #5.
- Multi-language syntax checks (JS/TS, Python, shell, SQL) — post-MVP
  `critic:code-syntax`.
- CI workflow switch from `lint && format:check && ...` to
  `pnpm check:ci`, plus ADR-0009 recording the pipeline decision —
  separate follow-up PR immediately after this merges.