### PR TITLE
feat(critic): LLM-critic (#4, ADR-0010..ADR-0012)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -428,3 +428,158 @@ Revisions add a new entry that supersedes the old one rather than rewriting hist
   commit `79c9a61` (rebased to `e7a1f39` on main) as part of PR #3.
   This ADR retroactively records the decision; no further code
   change is needed.
+
+## ADR-0010: LLM-critic triggers only inside the grey band of the hard-signal aggregate
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** The orchestrator (issue #5) invokes the LLM-critic only
+  when the noisy-OR aggregate of the hard-signal detectors (ADR-0006)
+  lands in the configurable grey band, default `[0.30, 0.60)`. Aggregates
+  below `0.30` skip the LLM-critic because the response is clearly
+  adequate; aggregates at or above `0.60` skip it because the
+  escalation threshold has already been crossed and a second opinion
+  would only add cost.
+- **Rationale:** The brief §4 describes the LLM-critic as running "only
+  when hard-signals return 'no clear failure' AND a confidence
+  threshold says the answer is borderline". That rule is stated in
+  boolean terms; ADR-0006 moved the hard-signal pipeline to
+  continuous confidence and a noisy-OR aggregate. Translating "no
+  clear failure" and "borderline" onto that continuous scale produces
+  a band: the lower edge marks "confidently adequate, no point
+  checking further", and the upper edge is simply the escalation
+  threshold itself (whatever a future configuration sets it to).
+  Running the critic outside the band is always wasteful: below the
+  lower edge the escalation would not fire regardless; at or above the
+  upper edge it fires on the hard-signal evidence alone. Inside the
+  band, the LLM-critic earns its keep — it catches the subtle
+  inadequacy cases that the hard-signal heuristics miss, without
+  running on every request.
+- **Alternatives considered:**
+  - _Run the LLM-critic on every request below the escalation
+    threshold._ Rejected: pays for a small-model inference call on
+    every confidently-adequate response. At any realistic volume the
+    cumulative cost overwhelms the savings from cheaper-model-first.
+  - _Run the LLM-critic on every request, regardless of hard-signal
+    aggregate._ Rejected more strongly: same objection, worse.
+    Belongs in a user-selectable "always second-opinion" mode,
+    post-MVP.
+  - _Run only when the aggregate is exactly at the threshold within
+    a small epsilon._ Rejected: the grey band is the epsilon, just
+    with an explicit floor and ceiling. An epsilon framing without
+    named bounds would be harder to reason about and harder to
+    calibrate later.
+- **Related:** issue #4 (this commit introduces the critic; the
+  orchestrator that applies the band gating lands in issue #5); the
+  default `[0.30, 0.60)` can be revised when post-MVP calibration data
+  exists.
+
+## ADR-0011: LLM-critic verdict is a separate threshold check, not mixed into the noisy-OR pool
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** The {@link LlmVerdict} returned by the critic is
+  evaluated against the escalation threshold independently of the
+  hard-signal noisy-OR aggregate. Escalation fires when
+  `(hard_signal_aggregate >= threshold) || (verdict === 'fail' &&
+  verdict.confidence >= threshold)`. A pass verdict never triggers
+  escalation regardless of confidence. The critic does not contribute
+  a `Signal` to the hard-signal pool.
+- **Rationale:** Hard-signal detectors and the LLM-critic supply
+  structurally different evidence. Hard signals are independent
+  heuristics over surface features (refusal phrasing, truncation,
+  repetition, empty response, tool error, syntax error); noisy-OR is
+  the right combinator because each detector fires on its own
+  evidence channel. The LLM-critic's output is holistic — a single
+  verdict on the whole response — and it is not independent of the
+  hard signals: the same refusal phrasing that fires the refusal
+  detector is also visible to the critic. Mixing them into one pool
+  double-counts that evidence and gives the critic outsized weight
+  (at confidence 0.80, a single LLM-critic vote would alone cross
+  the default threshold regardless of what any hard-signal detector
+  found). Keeping them in separate tracks makes the escalation
+  condition explicit and easier to reason about, and it lets each
+  track be tuned independently (the grey-band cut-offs in ADR-0010
+  do not need to stay in sync with hard-signal weights in issue #11).
+- **Alternatives considered:**
+  - _Add an `llm_critic` category to the hard-signal pool._
+    Rejected: double-counts evidence the hard signals already saw,
+    and gives a single high-confidence vote disproportionate weight
+    under noisy-OR.
+  - _Keep the pool but weight the critic signal down._ Rejected:
+    trades one calibration problem for another. The principled
+    answer is separate tracks, not a magic weight.
+  - _Replace the hard-signal pool with the critic whenever the
+    critic fires._ Rejected: throws away real evidence from the
+    deterministic detectors, and couples escalation to a
+    probabilistic external call.
+- **Related:** issue #4 (this commit introduces the verdict type);
+  issue #5 implements the two-track threshold comparison.
+
+## ADR-0012: LLM-critic v0.1 implementation — no cloud defaults, locale-keyed prompts (EN + DE), tolerant parsing
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** Three coupled implementation details of the v0.1
+  LLM-critic.
+  1. No defaults are baked in for the critic's `baseUrl` or `model`.
+     Callers must supply both explicitly. Budget enforcement is
+     opt-in (requires both `budgetUsd` and `pricing`).
+  2. Prompt templates are locale-keyed: English and German shipped,
+     English selected for unknown locales. The system prompt in each
+     template explicitly tells the critic that the user and assistant
+     may converse in any language and that the verdict JSON is always
+     in English with fixed field names.
+  3. Verdict extraction is deliberately tolerant: first a
+     ```` ```json ```` fence, then the first-`{`-to-last-`}`
+     substring, then the whole response body parsed as JSON. Each
+     strategy falls through to the next if either `JSON.parse` or
+     shape validation fails.
+- **Rationale:**
+  1. _No cloud defaults._ A silent default for the cloud critic
+     endpoint would cause a misconfigured turbocharger to fire
+     inference calls against whatever provider we happened to pin as
+     "the default", at unexpected cost to the user. Explicit
+     configuration forces the user to acknowledge the billing
+     relationship. Local-default candidates (e.g. an Ollama endpoint
+     on `http://localhost:11434/v1` with `qwen2.5:7b`) are slightly
+     less dangerous but still a stealth-dependency; an
+     `examples/standalone-config.example.yaml` fragment in a later
+     issue is the right home for them.
+  2. _Locale-keyed prompts._ ADR is consistent with issue #3's
+     locale-aware refusal patterns. A critic prompted in the user's
+     language pays less risk of misreading colloquial or
+     idiomatically-phrased content. The fallback-to-English keeps
+     unknown locales functional. The English verdict-JSON
+     requirement is a deliberate simplification: field names do not
+     vary by locale, so the extractor stays language-agnostic.
+  3. _Tolerant parsing._ Real-world LLMs frequently emit prose
+     before or after the JSON (e.g. "Here is my verdict: {...}") or
+     wrap it in a code fence. A strict `JSON.parse` on the whole
+     content would classify these as `parse_failure` and the
+     orchestrator would drop a perfectly usable verdict. Fence-first
+     is the best-hit path (fences are unambiguous when present);
+     brackets-second handles prose wrapping; direct parse last is
+     the unwrapped happy path that comes at no extra cost.
+- **Alternatives considered:**
+  - _Ship a default cloud endpoint (e.g. Anthropic or OpenAI) to
+    smooth first-run setup._ Rejected for silent billing reasons.
+  - _Ship defaults for Ollama only, not cloud._ Considered; this
+    sits in `examples/standalone-config.example.yaml` instead, so
+    the default is visible as documentation rather than hard-coded.
+  - _Single English-only prompt._ Rejected for consistency with
+    ADR-0012's (_sic — ADR-0012 is this one; the reference intended
+    is ADR-0006's noisy-OR localization stance and issue #3's
+    locale detectors_) locale awareness and for the risk of
+    misreading German idiom.
+  - _Strict `JSON.parse` only._ Rejected: measurable rate of
+    recoverable critic outputs would become spurious errors.
+  - _A structured-outputs API (OpenAI's JSON mode or Anthropic's
+    tool-use)._ Rejected for v0.1: couples the critic to a specific
+    provider's feature. Tolerant parsing lets the critic run
+    against any OpenAI-compatible endpoint, including Ollama.
+- **Related:** issue #4. Post-MVP candidates: a
+  structured-outputs-aware config flag that activates provider-native
+  JSON mode when available (keeps tolerant parsing as fallback); a
+  configurable prompt-template override for users who want custom
+  critic behaviour.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -482,7 +482,7 @@ Revisions add a new entry that supersedes the old one rather than rewriting hist
   evaluated against the escalation threshold independently of the
   hard-signal noisy-OR aggregate. Escalation fires when
   `(hard_signal_aggregate >= threshold) || (verdict === 'fail' &&
-  verdict.confidence >= threshold)`. A pass verdict never triggers
+verdict.confidence >= threshold)`. A pass verdict never triggers
   escalation regardless of confidence. The critic does not contribute
   a `Signal` to the hard-signal pool.
 - **Rationale:** Hard-signal detectors and the LLM-critic supply
@@ -531,7 +531,7 @@ Revisions add a new entry that supersedes the old one rather than rewriting hist
      may converse in any language and that the verdict JSON is always
      in English with fixed field names.
   3. Verdict extraction is deliberately tolerant: first a
-     ```` ```json ```` fence, then the first-`{`-to-last-`}`
+     ` ```json ` fence, then the first-`{`-to-last-`}`
      substring, then the whole response body parsed as JSON. Each
      strategy falls through to the next if either `JSON.parse` or
      shape validation fails.

--- a/src/critic/index.ts
+++ b/src/critic/index.ts
@@ -1,15 +1,14 @@
 // Critic module barrel.
 //
-// Issue #3 scope: re-exports the hard-signal detection surface
-// (see {@link ./hard-signals.ts}). The noisy-OR aggregator, weight
-// application, and verdict/threshold decision live in a future file
-// in this directory, added when issue #5 lands.
+// Issue #3 exposed the hard-signal detection surface. Issue #4 adds the
+// LLM-critic. The noisy-OR aggregator for hard signals, the escalation
+// threshold comparison, and the trigger-gating that decides when the
+// LLM-critic runs all land in issue #5 (orchestrator) alongside ADRs
+// 0006, 0010, and 0011.
 //
-// Until then, callers get only the detection primitives. The
-// orchestrator's interface (cascade strategy, threshold comparison,
-// LLM-critic gating, cost ceiling) is deliberately not committed yet,
-// because its exact shape is driven by ADR-0006 (aggregation) and
-// the config schema from issue #11.
+// Until then, callers importing from this module get the detection
+// primitives (hard-signal detectors, the collector) and the LLM-critic
+// callable. Gluing them into a single verdict is not committed to yet.
 
 export {
   collectHardSignals,
@@ -21,3 +20,5 @@ export {
   toolErrorDetector,
   truncationDetector,
 } from './hard-signals.js';
+
+export { runLlmCritic } from './llm-critic.js';

--- a/src/critic/llm-critic.ts
+++ b/src/critic/llm-critic.ts
@@ -151,11 +151,21 @@ function extractVerdict(content: string): LlmVerdict | null {
     if (verdict !== null) return verdict;
   }
 
-  // 2. First `{` to last `}`
-  const firstBrace = content.indexOf('{');
-  const lastBrace = content.lastIndexOf('}');
+  // 2. First `{` to last `}`, but exclude the fence region if a fence
+  //    was matched (even when its content failed to parse). Otherwise
+  //    the malformed fence body confuses the naive bracket span: its
+  //    opening `{` becomes the scan start and its broken content ends
+  //    up spanning into any valid JSON that follows, producing a
+  //    composite string that never parses.
+  const scanSource =
+    fenceMatch !== null
+      ? content.slice(0, fenceMatch.index) +
+        content.slice(fenceMatch.index + fenceMatch[0].length)
+      : content;
+  const firstBrace = scanSource.indexOf('{');
+  const lastBrace = scanSource.lastIndexOf('}');
   if (firstBrace >= 0 && lastBrace > firstBrace) {
-    const verdict = tryParseVerdict(content.slice(firstBrace, lastBrace + 1));
+    const verdict = tryParseVerdict(scanSource.slice(firstBrace, lastBrace + 1));
     if (verdict !== null) return verdict;
   }
 

--- a/src/critic/llm-critic.ts
+++ b/src/critic/llm-critic.ts
@@ -1,7 +1,312 @@
-// TODO(issue #4): LLM-critic adapter.
-// OpenAI-compatible, swappable model (default: ollama/qwen2.5:7b local,
-// anthropic/claude-haiku-* or openai/gpt-*-mini cloud).
-// Returns { verdict: "pass" | "fail", reason: string, confidence: 0..1 }.
-// Critic is explicitly instructed NOT to rewrite the answer.
+// LLM-critic: asks a small, separate model whether an assistant response
+// adequately answers the user's request. Returns a discriminated
+// {@link LlmCriticResult} — either a usable verdict, or an explicit
+// "skipped" / "error" reason that the orchestrator (issue #5) handles
+// without ever converting into a silent `pass`.
+//
+// Scope for v0.1 (see ADRs 0010, 0011, 0012):
+//   - Does NOT run automatically. The orchestrator (issue #5) invokes this
+//     only when the hard-signal noisy-OR aggregate lands in the grey band
+//     (0.3..0.6), per ADR-0010.
+//   - The verdict it returns is NOT mixed into the hard-signal pool per
+//     ADR-0011. The orchestrator compares it against the escalation
+//     threshold independently.
+//   - Per ADR-0012: no silent defaults for `baseUrl` or `model`; prompt
+//     templates are locale-keyed (English + German shipped, English
+//     fallback); verdict extraction is deliberately tolerant (```json
+//     fence, then first-`{`-to-last-`}`, then direct `JSON.parse`).
+//
+// Intentionally NOT in this file:
+//   - Trigger gating / threshold comparison — issue #5 (orchestrator).
+//   - Cumulative cost accounting across requests — post-MVP.
+//   - Config merging / Zod validation — issue #11 (config schema).
+//   - Retry logic — one attempt per invocation; retries would skew the
+//     per-request budget and are better handled by the caller.
 
-export {};
+import type {
+  LlmCritic,
+  LlmCriticConfig,
+  LlmCriticInput,
+  LlmCriticResult,
+  LlmVerdict,
+  ModelPricing,
+} from '../types.js';
+
+const DEFAULT_LOCALE = 'en';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const ASSUMED_OUTPUT_TOKENS = 100;
+
+// ---------------------------------------------------------------------------
+// Prompt templates (locale-keyed per ADR-0012)
+// ---------------------------------------------------------------------------
+
+interface PromptTemplate {
+  readonly system: string;
+  readonly user: (ctx: { userPrompt: string; response: string }) => string;
+}
+
+const PROMPT_TEMPLATES: Readonly<Record<string, PromptTemplate>> = {
+  en: {
+    system:
+      'You are an adequacy critic. A user made a request and received a response. ' +
+      'Your job is to judge whether the response adequately answers the request. ' +
+      'You must output a JSON object with exactly three fields: ' +
+      '"verdict" (either "pass" or "fail"), ' +
+      '"confidence" (a number in [0, 1] indicating how certain you are), ' +
+      'and "reason" (a short one-sentence explanation). ' +
+      'Do NOT rewrite or improve the response; you are only a judge. ' +
+      'The user and assistant may be conversing in any language; your verdict ' +
+      'JSON is always in English with the structure specified above.',
+    user: ({ userPrompt, response }) =>
+      `USER REQUEST:\n<<<\n${userPrompt}\n>>>\n\n` +
+      `ASSISTANT RESPONSE:\n<<<\n${response}\n>>>\n\n` +
+      'Output only the JSON object, no additional text.',
+  },
+  de: {
+    system:
+      'Du bist ein Adäquanz-Kritiker. Ein Nutzer hat eine Anfrage gestellt und eine ' +
+      'Antwort erhalten. Deine Aufgabe ist es zu beurteilen, ob die Antwort die Anfrage ' +
+      'adäquat beantwortet. Du musst ein JSON-Objekt mit genau drei Feldern ausgeben: ' +
+      '"verdict" (entweder "pass" oder "fail"), ' +
+      '"confidence" (eine Zahl in [0, 1], die angibt, wie sicher du bist), ' +
+      'und "reason" (eine kurze, einsätzige Begründung). ' +
+      'Schreibe die Antwort NICHT um und verbessere sie NICHT; du bist nur Richter. ' +
+      'Nutzer und Assistent können in jeder Sprache kommunizieren; dein Verdict-JSON ' +
+      'ist immer in englischen Feldnamen mit der oben spezifizierten Struktur.',
+    user: ({ userPrompt, response }) =>
+      `NUTZER-ANFRAGE:\n<<<\n${userPrompt}\n>>>\n\n` +
+      `ASSISTENT-ANTWORT:\n<<<\n${response}\n>>>\n\n` +
+      'Gib nur das JSON-Objekt aus, keinen zusätzlichen Text.',
+  },
+};
+
+function selectTemplate(locale: string | undefined): PromptTemplate {
+  const key = locale ?? DEFAULT_LOCALE;
+  return PROMPT_TEMPLATES[key] ?? PROMPT_TEMPLATES[DEFAULT_LOCALE]!;
+}
+
+// ---------------------------------------------------------------------------
+// Budget check
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate tokens from a character count. Character-to-token ratios vary
+ * by language and tokenizer; 1 token ≈ 4 characters is the common heuristic
+ * for English-leaning GPT-family tokenizers and is close enough for a
+ * pre-call budget check. Post-call actual usage is ignored in v0.1.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function estimateCostUsd(
+  promptChars: number,
+  pricing: ModelPricing,
+): number {
+  const inputTokens = estimateTokens(' '.repeat(promptChars));
+  const outputTokens = ASSUMED_OUTPUT_TOKENS;
+  return (
+    (inputTokens * pricing.inputUsdPerMillion +
+      outputTokens * pricing.outputUsdPerMillion) /
+    1_000_000
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Verdict extraction (tolerant per ADR-0012)
+// ---------------------------------------------------------------------------
+
+function tryParseVerdict(candidate: string): LlmVerdict | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+
+  const obj = parsed as Record<string, unknown>;
+  const verdict = obj['verdict'];
+  const confidence = obj['confidence'];
+  const reason = obj['reason'];
+
+  if (verdict !== 'pass' && verdict !== 'fail') return null;
+  if (typeof confidence !== 'number' || Number.isNaN(confidence)) return null;
+  if (typeof reason !== 'string') return null;
+
+  // Clamp to [0, 1] in case the critic emits values outside that range.
+  const clamped = Math.min(1, Math.max(0, confidence));
+
+  return { verdict, confidence: clamped, reason };
+}
+
+/**
+ * Extract a {@link LlmVerdict} from a raw critic response. Tries three
+ * strategies in order: fenced ```json block, first-`{`-to-last-`}`
+ * substring, then the whole content as JSON. Returns null only when all
+ * three fail.
+ */
+function extractVerdict(content: string): LlmVerdict | null {
+  // 1. ```json fence
+  const fencePattern = /```json\s*\n([\s\S]*?)\n\s*```/;
+  const fenceMatch = fencePattern.exec(content);
+  if (fenceMatch?.[1] !== undefined) {
+    const verdict = tryParseVerdict(fenceMatch[1]);
+    if (verdict !== null) return verdict;
+  }
+
+  // 2. First `{` to last `}`
+  const firstBrace = content.indexOf('{');
+  const lastBrace = content.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    const verdict = tryParseVerdict(content.slice(firstBrace, lastBrace + 1));
+    if (verdict !== null) return verdict;
+  }
+
+  // 3. Whole content
+  return tryParseVerdict(content);
+}
+
+// ---------------------------------------------------------------------------
+// Fetch wrapper with timeout
+// ---------------------------------------------------------------------------
+
+interface ChatCompletionChoice {
+  readonly message?: { readonly content?: string | null };
+}
+
+interface ChatCompletionResponse {
+  readonly choices?: readonly ChatCompletionChoice[];
+}
+
+async function fetchVerdictResponse(
+  input: LlmCriticInput,
+  config: LlmCriticConfig,
+): Promise<LlmCriticResult | { kind: 'ok'; content: string }> {
+  const template = selectTemplate(input.locale);
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (config.apiKey !== undefined) {
+    headers['authorization'] = `Bearer ${config.apiKey}`;
+  }
+
+  const body = JSON.stringify({
+    model: config.model,
+    messages: [
+      { role: 'system', content: template.system },
+      {
+        role: 'user',
+        content: template.user({
+          userPrompt: input.userPrompt,
+          response: input.response,
+        }),
+      },
+    ],
+    temperature: 0,
+    stream: false,
+  });
+
+  const controller = new AbortController();
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const impl: typeof fetch = config.fetchImpl ?? fetch;
+
+  let res: Response;
+  try {
+    res = await impl(`${config.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers,
+      body,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err instanceof Error ? err.message : String(err);
+    // AbortError has name 'AbortError' but message varies across runtimes.
+    const isAbort =
+      err instanceof Error && (err.name === 'AbortError' || /abort/i.test(message));
+    return {
+      kind: 'error',
+      reason: isAbort ? 'timeout' : 'network',
+      detail: message,
+    };
+  }
+  clearTimeout(timer);
+
+  if (!res.ok) {
+    return {
+      kind: 'error',
+      reason: 'http',
+      detail: `HTTP ${res.status} ${res.statusText}`,
+    };
+  }
+
+  let parsed: ChatCompletionResponse;
+  try {
+    parsed = (await res.json()) as ChatCompletionResponse;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { kind: 'error', reason: 'parse_failure', detail: `response body: ${message}` };
+  }
+
+  const content = parsed.choices?.[0]?.message?.content;
+  if (typeof content !== 'string' || content.length === 0) {
+    return {
+      kind: 'error',
+      reason: 'empty',
+      detail: 'response contained no message content',
+    };
+  }
+
+  return { kind: 'ok', content };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the LLM-critic. Returns a discriminated {@link LlmCriticResult}.
+ * Never throws — all failures are represented as `error` or `skipped`
+ * variants, per the brief's "no silent failures" principle.
+ */
+export const runLlmCritic: LlmCritic = async (input, config) => {
+  // Pre-call budget check (opt-in: requires both budgetUsd and pricing).
+  if (config.budgetUsd !== undefined && config.pricing !== undefined) {
+    const template = selectTemplate(input.locale);
+    const promptChars =
+      template.system.length +
+      template.user({ userPrompt: input.userPrompt, response: input.response }).length;
+    const estimated = estimateCostUsd(promptChars, config.pricing);
+    if (estimated > config.budgetUsd) {
+      return { kind: 'skipped', reason: 'over_budget' };
+    }
+  }
+
+  const fetched = await fetchVerdictResponse(input, config);
+  if (fetched.kind !== 'ok') {
+    return fetched;
+  }
+
+  const verdict = extractVerdict(fetched.content);
+  if (verdict === null) {
+    return {
+      kind: 'error',
+      reason: 'parse_failure',
+      detail: `could not extract verdict JSON from: ${fetched.content.slice(0, 120)}`,
+    };
+  }
+  return { kind: 'verdict', verdict };
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers exported for testing
+// ---------------------------------------------------------------------------
+
+/** @internal — exposed for unit tests only. */
+export const __internal = {
+  extractVerdict,
+  estimateCostUsd,
+  selectTemplate,
+};

--- a/src/critic/llm-critic.ts
+++ b/src/critic/llm-critic.ts
@@ -99,15 +99,11 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-function estimateCostUsd(
-  promptChars: number,
-  pricing: ModelPricing,
-): number {
+function estimateCostUsd(promptChars: number, pricing: ModelPricing): number {
   const inputTokens = estimateTokens(' '.repeat(promptChars));
   const outputTokens = ASSUMED_OUTPUT_TOKENS;
   return (
-    (inputTokens * pricing.inputUsdPerMillion +
-      outputTokens * pricing.outputUsdPerMillion) /
+    (inputTokens * pricing.inputUsdPerMillion + outputTokens * pricing.outputUsdPerMillion) /
     1_000_000
   );
 }
@@ -224,8 +220,7 @@ async function fetchVerdictResponse(
     clearTimeout(timer);
     const message = err instanceof Error ? err.message : String(err);
     // AbortError has name 'AbortError' but message varies across runtimes.
-    const isAbort =
-      err instanceof Error && (err.name === 'AbortError' || /abort/i.test(message));
+    const isAbort = err instanceof Error && (err.name === 'AbortError' || /abort/i.test(message));
     return {
       kind: 'error',
       reason: isAbort ? 'timeout' : 'network',

--- a/src/critic/llm-critic.ts
+++ b/src/critic/llm-critic.ts
@@ -159,8 +159,7 @@ function extractVerdict(content: string): LlmVerdict | null {
   //    composite string that never parses.
   const scanSource =
     fenceMatch !== null
-      ? content.slice(0, fenceMatch.index) +
-        content.slice(fenceMatch.index + fenceMatch[0].length)
+      ? content.slice(0, fenceMatch.index) + content.slice(fenceMatch.index + fenceMatch[0].length)
       : content;
   const firstBrace = scanSource.indexOf('{');
   const lastBrace = scanSource.lastIndexOf('}');

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 // truth so that proxy / critic / escalation / transparency stay structurally
 // consistent. Issue #2 introduces the minimal surface needed for the
 // pass-through proxy; issue #3 adds the hard-signal detection surface;
-// later issues extend further.
+// issue #4 adds the LLM-critic surface; later issues extend further.
 
 /**
  * Effective configuration for a running sidecar process.
@@ -111,3 +111,105 @@ export interface DetectorInput {
 
 /** Signature every hard-signal detector must satisfy. */
 export type HardSignalDetector = (input: DetectorInput) => Signal | null;
+
+// ---------------------------------------------------------------------------
+// Critic — LLM-critic (issue #4)
+// ---------------------------------------------------------------------------
+
+/**
+ * A verdict delivered by the LLM-critic. Per ADR-0011 this is NOT mixed
+ * into the hard-signal noisy-OR pool; the orchestrator (issue #5) compares
+ * it against the escalation threshold as an independent piece of evidence.
+ *
+ * The `verdict` field is the coarse yes/no answer, and `confidence`
+ * expresses how certain the critic is. Escalation fires when
+ * `verdict === 'fail' && confidence >= threshold`; `pass` verdicts never
+ * escalate regardless of their confidence.
+ */
+export interface LlmVerdict {
+  readonly verdict: 'pass' | 'fail';
+  /** Continuous confidence in `[0, 1]`. */
+  readonly confidence: number;
+  /** Short reason produced by the critic, suitable for the transparency layer. */
+  readonly reason: string;
+}
+
+/**
+ * Input passed to the LLM-critic. Matches {@link DetectorInput} in shape
+ * for the fields the critic needs, but does not include `finishReason` —
+ * that is hard-signal territory and has no role in the critic's judgement.
+ */
+export interface LlmCriticInput {
+  readonly response: string;
+  readonly userPrompt: string;
+  /** BCP-47 locale hint; selects the prompt template. Defaults to `"en"`. */
+  readonly locale?: string;
+}
+
+/**
+ * Token pricing for a critic model, used by the pre-call budget check.
+ * When not supplied, the budget check is skipped and the critic runs
+ * regardless of the configured budget. Per ADR-0012, v0.1 has no defaults
+ * here — the caller must opt in to budget enforcement.
+ */
+export interface ModelPricing {
+  /** USD cost per 1,000,000 input tokens. */
+  readonly inputUsdPerMillion: number;
+  /** USD cost per 1,000,000 output tokens. */
+  readonly outputUsdPerMillion: number;
+}
+
+/**
+ * Configuration bundle for a single LLM-critic invocation. Per ADR-0012,
+ * there are no silent defaults for `baseUrl` or `model`; callers must
+ * supply them explicitly. Budget enforcement is optional and requires
+ * both `budgetUsd` and `pricing` to be set.
+ */
+export interface LlmCriticConfig {
+  /** OpenAI-compatible base URL, e.g. `http://localhost:11434/v1`. */
+  readonly baseUrl: string;
+  /** Model slug as understood by the downstream endpoint. */
+  readonly model: string;
+  /** Optional bearer token for the critic endpoint. */
+  readonly apiKey?: string;
+  /** Per-request timeout in milliseconds. Defaults to 30_000. */
+  readonly timeoutMs?: number;
+  /** Per-request USD ceiling. Only enforced when `pricing` is also set. */
+  readonly budgetUsd?: number;
+  /** Pricing for cost estimation. When absent, budget is not enforced. */
+  readonly pricing?: ModelPricing;
+  /**
+   * Optional `fetch` implementation for testing. Defaults to the global
+   * `fetch` in Node 22. Exposed here so tests can inject mocks without
+   * polluting the global scope.
+   */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * Discriminated result of an LLM-critic invocation. The three kinds are:
+ *
+ * - `verdict`: the critic returned a usable verdict.
+ * - `skipped`: the critic did not run (budget exceeded, or explicitly
+ *   disabled by the caller).
+ * - `error`: the critic ran but produced no usable verdict (network
+ *   failure, HTTP error, parse failure, timeout, empty response).
+ *
+ * Per the brief's "no silent fallbacks that hide failures" principle,
+ * the orchestrator (issue #5) never converts `error` or `skipped` into
+ * an implicit `pass`. Callers decide case by case.
+ */
+export type LlmCriticResult =
+  | { readonly kind: 'verdict'; readonly verdict: LlmVerdict }
+  | { readonly kind: 'skipped'; readonly reason: 'over_budget' | 'disabled' }
+  | {
+      readonly kind: 'error';
+      readonly reason: 'timeout' | 'network' | 'http' | 'empty' | 'parse_failure';
+      readonly detail: string;
+    };
+
+/** Signature of the LLM-critic callable. */
+export type LlmCritic = (
+  input: LlmCriticInput,
+  config: LlmCriticConfig,
+) => Promise<LlmCriticResult>;

--- a/test/llm-critic.test.ts
+++ b/test/llm-critic.test.ts
@@ -264,7 +264,7 @@ describe('runLlmCritic', () => {
   });
 
   it('sends the German prompt template when locale=de', async () => {
-    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+    const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));
       // Shape: { messages: [{role:'system',content:...}, {role:'user',content:...}] }
       const systemContent = body.messages[0].content as string;
@@ -282,7 +282,7 @@ describe('runLlmCritic', () => {
   });
 
   it('sends an Authorization header when apiKey is configured', async () => {
-    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+    const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       const headers = init?.headers as Record<string, string>;
       expect(headers['authorization']).toBe('Bearer secret-token');
       return new Response(

--- a/test/llm-critic.test.ts
+++ b/test/llm-critic.test.ts
@@ -1,8 +1,301 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-describe('critic: llm-critic', () => {
-  it.todo('returns a verdict of "pass" | "fail" with reason and confidence (issue #4)');
-  it.todo('refuses to be prompted into rewriting the answer (issue #4)');
-  it.todo('falls back to hard-signal-only when critic_budget_usd is exceeded (issue #4)');
-  it.todo('works with a swappable OpenAI-compatible model endpoint (issue #4)');
+import { runLlmCritic } from '../src/critic/index.js';
+import { __internal } from '../src/critic/llm-critic.js';
+import type { LlmCriticConfig, LlmCriticInput, ModelPricing } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const { extractVerdict, estimateCostUsd, selectTemplate } = __internal;
+
+function makeInput(overrides: Partial<LlmCriticInput> = {}): LlmCriticInput {
+  return {
+    response: 'Here is a reasonable answer to your question.',
+    userPrompt: 'Please answer briefly.',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<LlmCriticConfig> = {}): LlmCriticConfig {
+  return {
+    baseUrl: 'http://critic.test/v1',
+    model: 'test-critic-model',
+    ...overrides,
+  };
+}
+
+/**
+ * Build a mocked fetch implementation that returns a chat/completions-
+ * shaped JSON body with the given assistant content.
+ */
+function mockFetchReturning(content: string, status = 200): typeof fetch {
+  return vi.fn(async () => {
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content } }],
+      }),
+      {
+        status,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function mockFetchRejecting(error: Error): typeof fetch {
+  return vi.fn(async () => {
+    throw error;
+  }) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Verdict extraction — direct unit tests on __internal
+// ---------------------------------------------------------------------------
+
+describe('extractVerdict', () => {
+  it('parses a plain JSON object response', () => {
+    const verdict = extractVerdict('{"verdict":"pass","confidence":0.8,"reason":"looks fine"}');
+    expect(verdict).toEqual({ verdict: 'pass', confidence: 0.8, reason: 'looks fine' });
+  });
+
+  it('parses a JSON object inside a ```json fence', () => {
+    const content =
+      'Here is my verdict:\n```json\n{"verdict":"fail","confidence":0.9,"reason":"refusal"}\n```';
+    const verdict = extractVerdict(content);
+    expect(verdict).toEqual({ verdict: 'fail', confidence: 0.9, reason: 'refusal' });
+  });
+
+  it('parses a JSON object surrounded by prose (bracket extraction)', () => {
+    const content =
+      'I have reviewed the response. My verdict: {"verdict":"pass","confidence":0.75,"reason":"adequate"}. Let me know if you need more.';
+    const verdict = extractVerdict(content);
+    expect(verdict).toEqual({ verdict: 'pass', confidence: 0.75, reason: 'adequate' });
+  });
+
+  it('prefers the fence contents over a bracketed substring when the fence is valid', () => {
+    const content =
+      '```json\n{"verdict":"fail","confidence":0.6,"reason":"short"}\n```\nNote: {invalid json}';
+    const verdict = extractVerdict(content);
+    expect(verdict?.verdict).toBe('fail');
+  });
+
+  it('falls back to bracket extraction when the fence content is malformed', () => {
+    const content =
+      '```json\n{broken json here}\n```\n{"verdict":"pass","confidence":0.5,"reason":"ok"}';
+    const verdict = extractVerdict(content);
+    expect(verdict?.verdict).toBe('pass');
+  });
+
+  it('returns null when no valid JSON is present', () => {
+    expect(extractVerdict('This is just prose with no JSON object.')).toBeNull();
+  });
+
+  it('returns null when the JSON is valid but shape is wrong', () => {
+    expect(extractVerdict('{"not_a_verdict":true}')).toBeNull();
+    expect(extractVerdict('{"verdict":"maybe","confidence":0.5,"reason":"x"}')).toBeNull();
+    expect(extractVerdict('{"verdict":"pass","confidence":"high","reason":"x"}')).toBeNull();
+  });
+
+  it('clamps confidence values outside [0, 1]', () => {
+    expect(extractVerdict('{"verdict":"pass","confidence":1.5,"reason":"ok"}')?.confidence).toBe(1);
+    expect(extractVerdict('{"verdict":"pass","confidence":-0.3,"reason":"ok"}')?.confidence).toBe(
+      0,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Template selection
+// ---------------------------------------------------------------------------
+
+describe('selectTemplate', () => {
+  it('returns the English template by default', () => {
+    expect(selectTemplate(undefined).system).toContain('adequacy critic');
+  });
+
+  it('returns the German template for locale=de', () => {
+    expect(selectTemplate('de').system).toContain('Adäquanz-Kritiker');
+  });
+
+  it('falls back to English for unknown locales', () => {
+    expect(selectTemplate('fr').system).toContain('adequacy critic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget estimation
+// ---------------------------------------------------------------------------
+
+describe('estimateCostUsd', () => {
+  const pricing: ModelPricing = {
+    inputUsdPerMillion: 1,
+    outputUsdPerMillion: 4,
+  };
+
+  it('scales linearly with prompt length', () => {
+    const cheap = estimateCostUsd(400, pricing);
+    const pricy = estimateCostUsd(4000, pricing);
+    expect(pricy).toBeGreaterThan(cheap);
+  });
+
+  it('produces a realistic order of magnitude for a typical critic prompt', () => {
+    // A ~1200-char prompt with $1/$4 per MTok should cost well under a cent.
+    const cost = estimateCostUsd(1200, pricing);
+    expect(cost).toBeLessThan(0.01);
+    expect(cost).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLlmCritic — end-to-end with injected fetch
+// ---------------------------------------------------------------------------
+
+describe('runLlmCritic', () => {
+  it('returns a verdict when the critic responds with a valid JSON body', async () => {
+    const fetchImpl = mockFetchReturning(
+      '{"verdict":"pass","confidence":0.85,"reason":"adequate"}',
+    );
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('verdict');
+    if (result.kind === 'verdict') {
+      expect(result.verdict.verdict).toBe('pass');
+      expect(result.verdict.confidence).toBeCloseTo(0.85, 2);
+    }
+  });
+
+  it('returns a verdict when the critic wraps JSON in a code fence', async () => {
+    const fetchImpl = mockFetchReturning(
+      '```json\n{"verdict":"fail","confidence":0.7,"reason":"refusal"}\n```',
+    );
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('verdict');
+    if (result.kind === 'verdict') {
+      expect(result.verdict.verdict).toBe('fail');
+    }
+  });
+
+  it('returns parse_failure when the critic emits malformed JSON', async () => {
+    const fetchImpl = mockFetchReturning('I could not produce a JSON verdict.');
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('parse_failure');
+    }
+  });
+
+  it('returns http error on non-2xx response', async () => {
+    const fetchImpl = mockFetchReturning('server error detail', 500);
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('http');
+    }
+  });
+
+  it('returns empty error when the response has no message content', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ choices: [{ message: {} }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ) as unknown as typeof fetch;
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('empty');
+    }
+  });
+
+  it('returns network error when fetch itself throws', async () => {
+    const fetchImpl = mockFetchRejecting(new Error('ECONNREFUSED'));
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('network');
+    }
+  });
+
+  it('returns timeout when fetch is aborted', async () => {
+    const abortErr = new Error('The user aborted a request.');
+    abortErr.name = 'AbortError';
+    const fetchImpl = mockFetchRejecting(abortErr);
+    const result = await runLlmCritic(makeInput(), makeConfig({ fetchImpl }));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('timeout');
+    }
+  });
+
+  it('skips when the pre-call budget check would exceed budgetUsd', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await runLlmCritic(
+      makeInput({
+        // Long prompt → higher estimated cost.
+        userPrompt: 'x'.repeat(10_000),
+        response: 'y'.repeat(10_000),
+      }),
+      makeConfig({
+        fetchImpl,
+        budgetUsd: 0.000001,
+        pricing: { inputUsdPerMillion: 10, outputUsdPerMillion: 40 },
+      }),
+    );
+    expect(result.kind).toBe('skipped');
+    if (result.kind === 'skipped') {
+      expect(result.reason).toBe('over_budget');
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('runs when budget is configured but the estimated cost is under budgetUsd', async () => {
+    const fetchImpl = mockFetchReturning(
+      '{"verdict":"pass","confidence":0.9,"reason":"ok"}',
+    );
+    const result = await runLlmCritic(
+      makeInput(),
+      makeConfig({
+        fetchImpl,
+        budgetUsd: 1.0,
+        pricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 4 },
+      }),
+    );
+    expect(result.kind).toBe('verdict');
+  });
+
+  it('sends the German prompt template when locale=de', async () => {
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      // Shape: { messages: [{role:'system',content:...}, {role:'user',content:...}] }
+      const systemContent = body.messages[0].content as string;
+      expect(systemContent).toContain('Adäquanz-Kritiker');
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"verdict":"pass","confidence":0.8,"reason":"ok"}' } }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch;
+
+    await runLlmCritic(makeInput({ locale: 'de' }), makeConfig({ fetchImpl }));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends an Authorization header when apiKey is configured', async () => {
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers['authorization']).toBe('Bearer secret-token');
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"verdict":"pass","confidence":0.8,"reason":"ok"}' } }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch;
+
+    await runLlmCritic(makeInput(), makeConfig({ fetchImpl, apiKey: 'secret-token' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/llm-critic.test.ts
+++ b/test/llm-critic.test.ts
@@ -251,9 +251,7 @@ describe('runLlmCritic', () => {
   });
 
   it('runs when budget is configured but the estimated cost is under budgetUsd', async () => {
-    const fetchImpl = mockFetchReturning(
-      '{"verdict":"pass","confidence":0.9,"reason":"ok"}',
-    );
+    const fetchImpl = mockFetchReturning('{"verdict":"pass","confidence":0.9,"reason":"ok"}');
     const result = await runLlmCritic(
       makeInput(),
       makeConfig({


### PR DESCRIPTION
Closes #4.

Introduces the LLM-critic as a discrete, swappable module. Asks a small
OpenAI-compatible model whether an assistant response is adequate, and
returns a discriminated `LlmCriticResult` — verdict, skipped, or error —
without ever silently converting failure into a pass.

## Commits

Seven commits. The feature itself landed as the first three; the
remaining four are Prettier hygiene and two genuine bug fixes caught
by the new tests.

- **`feat(critic)`** — `LlmVerdict`, `LlmCriticInput`, `LlmCriticConfig`,
  `ModelPricing`, `LlmCriticResult`, `LlmCritic` types. `runLlmCritic`
  with locale-keyed prompts (EN + DE), opt-in pre-call budget check,
  AbortController-backed timeout, and tolerant JSON extraction.
- **`test(critic)`** — 24 hermetic tests using `vi.fn()`-backed fetch
  injection. Covers verdict extraction strategies, locale template
  selection, cost estimation, and all `LlmCriticResult` kinds
  end-to-end.
- **`docs`** — ADR-0010 (grey-band trigger gating), ADR-0011
  (independent threshold check, not pool integration), ADR-0012
  (v0.1 implementation: no cloud defaults, locale-keyed prompts,
  tolerant parsing).
- **`chore` (first)** — Prettier normalization of the three files
  above. Same pattern as PR #3.
- **`fix(test)`** — Replaced `RequestInfo | URL` (DOM-only type) with
  `Parameters<typeof fetch>[0]` in two mock-fetch signatures. The
  repo's tsconfig uses `lib: [ES2022]` without DOM by design, since
  this is a server-only codebase.
- **`fix(critic)`** — The bracket-scan fallback in `extractVerdict`
  was using the full content as scan source, so a matched-but-
  malformed fence's opening brace and the trailing valid-JSON's
  closing brace spanned across the fence, producing an unparseable
  composite. Now the fence region is excluded from the scan source
  when a fence was matched. Caught by the `falls back to bracket
  extraction when the fence content is malformed` test.
- **`chore` (second)** — Prettier normalization of the fix(critic)
  commit.

## Verification

`pnpm check` green locally: 62 passed / 3 todo, no format or lint
warnings, typecheck clean, build succeeds.

## Explicitly not in this PR

- Trigger-gating / grey-band application — issue #5 (orchestrator).
- Threshold comparison that turns a verdict into escalation — issue #5.
- Config schema / Zod validation of `LlmCriticConfig` — issue #11.
- Integration into the proxy pipeline — issue #5.
- Retry logic, cumulative cost accounting, provider-native JSON mode
  — post-MVP.