### PR TITLE
chore: prettier normalization of fix(critic) commit

### DIFF
--- a/src/critic/llm-critic.ts
+++ b/src/critic/llm-critic.ts
@@ -159,8 +159,7 @@ function extractVerdict(content: string): LlmVerdict | null {
   //    composite string that never parses.
   const scanSource =
     fenceMatch !== null
-      ? content.slice(0, fenceMatch.index) +
-        content.slice(fenceMatch.index + fenceMatch[0].length)
+      ? content.slice(0, fenceMatch.index) + content.slice(fenceMatch.index + fenceMatch[0].length)
       : content;
   const firstBrace = scanSource.indexOf('{');
   const lastBrace = scanSource.lastIndexOf('}');


### PR DESCRIPTION
Follow-up to PR #6 (feat/4-llm-critic) which was rebase-merged while
this prettier-normalization commit was still only on the branch.
`main` currently fails `pnpm format:check` on `src/critic/llm-critic.ts`
without this commit.

Whitespace only — one line-break/line-length change in the
`extractVerdict` fallback chain. No logic change.

Cherry-picked from the closed feat/4-llm-critic branch.