### PR TITLE
feat(critic): orchestrator and pipeline (#5, ADR-0013..ADR-0015)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -602,7 +602,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   `test/proxy.test.ts` streaming assertion; (b) duplicating the
   stream with `.tee()` so one half streams to the client and the
   other accumulates for the orchestrator — which means the decision
-  is only available *after* the stream has finished, long past the
+  is only available _after_ the stream has finished, long past the
   HTTP headers, requiring trailers (poorly supported across clients)
   or body-level SSE events (which contradicts the "no body
   modification" posture we chose for v0.1, ADR-0007's in-stream
@@ -664,7 +664,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     kept-config ergonomic win is small when the caller is a single
     pipeline that already holds the config anyway.
   - _Closure-based factory: `createOrchestrator(config) =>
-    (input) => Decision`._ Rejected: hides the config dependency
+(input) => Decision`._ Rejected: hides the config dependency
     from stack traces and test-setup, for the same closure-bound
     ergonomic as the class form with none of the class's
     discoverability.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -583,3 +583,137 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   JSON mode when available (keeps tolerant parsing as fallback); a
   configurable prompt-template override for users who want custom
   critic behaviour.
+
+## ADR-0013: Adequacy checks are skipped for streaming responses in v0.1
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** When the client requests a streaming completion
+  (`stream: true`), the pipeline forwards the response unchanged to
+  the client, skips the orchestrator entirely, and records the skip
+  with `{ kind: 'skipped', reason: 'streaming' }`. The
+  `X-Turbocharger-Decision: skipped` header is set; no other
+  transparency layer runs.
+- **Rationale:** Streaming responses are `ReadableStream`s that must
+  reach the client before the assistant's content is assembled end
+  to end. Running the orchestrator against them requires either (a)
+  buffering the entire stream before forwarding — which breaks the
+  streaming contract and is guarded by the existing
+  `test/proxy.test.ts` streaming assertion; (b) duplicating the
+  stream with `.tee()` so one half streams to the client and the
+  other accumulates for the orchestrator — which means the decision
+  is only available *after* the stream has finished, long past the
+  HTTP headers, requiring trailers (poorly supported across clients)
+  or body-level SSE events (which contradicts the "no body
+  modification" posture we chose for v0.1, ADR-0007's in-stream
+  layer is Issue #9's territory); or (c) a stream-accumulator that
+  inspects a prefix and decides synchronously — which would need a
+  different, partial-response critic that we have not designed.
+  Option (a) is incompatible with the existing streaming contract;
+  (b) and (c) are each worth their own design round. Skipping for
+  v0.1 is honest: we surface the skip in headers and logs so
+  monitoring can track how often it happens, which gives us data for
+  a post-MVP design decision on streaming critics.
+- **Alternatives considered:**
+  - _Buffer the stream, run the critic, then forward._ Rejected:
+    breaks the streaming contract that issue #2 explicitly tested
+    and that users with latency-sensitive UIs depend on.
+  - _Tee the stream, decide after stream end, emit HTTP trailers._
+    Rejected for v0.1: trailer support in clients (`curl` without
+    `--raw`, browsers, many SDKs) is inconsistent. A decision
+    delivered via trailer is, for most consumers, no decision at
+    all.
+  - _Tee the stream, append a terminal SSE event with the
+    decision._ Rejected for v0.1: modifies the response body, which
+    this issue's design explicitly avoids (pipeline is pass-through
+    for bytes; transparency is via headers and logs only). Can be
+    revisited in Issue #9 alongside the banner/card modes, which do
+    modify the body by design.
+  - _Prefix-inspection critic that decides on the first N tokens._
+    Rejected: the adequacy heuristics (refusal, truncation,
+    repetition) reason about the whole response. A prefix critic
+    would be a different, more speculative detector that we have
+    not calibrated.
+- **Related:** issue #5 pipeline implementation; future post-MVP
+  work on streaming adequacy checks would revisit this ADR.
+
+## ADR-0014: Orchestrator is a pure function, not an object
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** `runOrchestrator(input, config): Promise<Decision>`
+  is a pure function. Configuration is passed per call rather than
+  captured in a constructor. No internal state is held between
+  calls.
+- **Rationale:** In v0.1 the orchestrator is genuinely stateless:
+  every invocation runs the hard-signal detectors, aggregates via
+  noisy-OR, and optionally invokes a caller-supplied LLM-critic.
+  None of that benefits from being a method on an object with
+  shared state. A pure function is simpler to test (no setup /
+  teardown), easier to reason about (the config is visible at every
+  call site), and trivially composable with the pipeline (which is
+  also a function). Should a future iteration accumulate state
+  across calls — a per-session cost counter, a decision-history
+  cache, a calibration-tracking layer — an `Orchestrator` class
+  wrapping this function is straightforward to build later. The
+  reverse (pulling state out of a class into separate function
+  arguments after it has already been used) is disproportionately
+  harder.
+- **Alternatives considered:**
+  - _`new Orchestrator(config).evaluate(input)`._ Rejected: the
+    kept-config ergonomic win is small when the caller is a single
+    pipeline that already holds the config anyway.
+  - _Closure-based factory: `createOrchestrator(config) =>
+    (input) => Decision`._ Rejected: hides the config dependency
+    from stack traces and test-setup, for the same closure-bound
+    ergonomic as the class form with none of the class's
+    discoverability.
+  - _Pass config as a top-level module export, set once at boot._
+    Rejected strongly: makes tests non-hermetic, couples unrelated
+    orchestrator invocations.
+- **Related:** issue #5 implementation; future post-MVP state work
+  (cost accounting, calibration) can wrap this function without
+  changing its public surface.
+
+## ADR-0015: The pipeline is a separate module, not a proxy feature
+
+- **Date:** 2026-04-20
+- **Status:** accepted
+- **Decision:** The code that runs the orchestrator against proxy
+  responses lives in `src/pipeline.ts`, a new top-level module.
+  `src/proxy.ts` remains responsible only for HTTP forwarding and
+  does not import the orchestrator or any critic. `src/server.ts`
+  composes the two: when an `orchestratorConfig` is supplied via
+  `AppDeps`, the request flows through `runPipeline`; otherwise
+  through `forwardChatCompletion` directly.
+- **Rationale:** The proxy's job is narrow and testable —
+  RFC-compliant forwarding, header hygiene, streaming passthrough.
+  Folding the adequacy check into the same file would force
+  `proxy.ts` to know about Signals, LlmVerdicts, noisy-OR, grey
+  bands, and X-Turbocharger headers. That is four layers of
+  concerns entangled in one file, and it makes proxy-level changes
+  (e.g. a different fetch implementation, an HTTP/2 upgrade) risky
+  because they would also touch critic code. Keeping the two
+  responsibilities separate costs one extra file and one import in
+  `server.ts`; it wins an explicit seam that can be tested, mocked,
+  and replaced independently. The pipeline module is also where
+  the issue #6 escalation machinery will plug in: after the
+  decision is made, it will optionally trigger a ladder/max
+  re-query before returning to the client. Having that all live
+  alongside the forwarding logic would continue entangling the
+  proxy.
+- **Alternatives considered:**
+  - _Add a critic hook to `forwardChatCompletion`._ Rejected: see
+    above.
+  - _Put the pipeline inline in `server.ts`._ Rejected: the server
+    already does HTTP routing, logging, and startup; adding the
+    orchestrator composition to it would make the file a
+    multi-concern hub.
+  - _Expose a class-based middleware_ (e.g. Hono middleware
+    function) _instead of a standalone module._ Considered; deferred
+    until Issue #6 (escalation) is done, because the middleware's
+    shape depends on how escalation changes the response flow.
+    When we know the final shape, we can convert the module to a
+    middleware if that simplification pays for itself.
+- **Related:** issue #5 pipeline module; issue #6 escalation will
+  extend `runPipeline` to act on `escalate` decisions.

--- a/src/critic/index.ts
+++ b/src/critic/index.ts
@@ -1,14 +1,13 @@
 // Critic module barrel.
 //
-// Issue #3 exposed the hard-signal detection surface. Issue #4 adds the
-// LLM-critic. The noisy-OR aggregator for hard signals, the escalation
-// threshold comparison, and the trigger-gating that decides when the
-// LLM-critic runs all land in issue #5 (orchestrator) alongside ADRs
-// 0006, 0010, and 0011.
+// Issue #3 exposed the hard-signal detection surface. Issue #4 added the
+// LLM-critic. Issue #5 adds the orchestrator that combines them into a
+// single decision via noisy-OR aggregation and grey-band gating.
 //
-// Until then, callers importing from this module get the detection
-// primitives (hard-signal detectors, the collector) and the LLM-critic
-// callable. Gluing them into a single verdict is not committed to yet.
+// Callers importing from this module get the detection primitives,
+// the LLM-critic callable, and the orchestrator. The pipeline that
+// wires the orchestrator in front of the proxy is in
+// {@link ../pipeline.ts}.
 
 export {
   collectHardSignals,
@@ -22,3 +21,5 @@ export {
 } from './hard-signals.js';
 
 export { runLlmCritic } from './llm-critic.js';
+
+export { aggregateSignals, runOrchestrator } from './orchestrator.js';

--- a/src/critic/orchestrator.ts
+++ b/src/critic/orchestrator.ts
@@ -1,0 +1,160 @@
+// Orchestrator: combines hard-signal evidence with an optional LLM-critic
+// verdict into a single {@link OrchestratorDecision}. Pure function, no
+// I/O of its own beyond invoking the caller-supplied LLM-critic.
+//
+// Scope (v0.1, issue #5):
+//   - Runs every enabled hard-signal detector (ADR-0006 noisy-OR
+//     aggregation with per-category weights).
+//   - Invokes the LLM-critic when the noisy-OR aggregate lands in the
+//     configurable grey band (ADR-0010, default [0.30, 0.60)).
+//   - The LLM-critic verdict is compared against the escalation
+//     threshold independently of the pool (ADR-0011). A fail verdict
+//     with confidence >= threshold escalates; pass verdicts never do,
+//     regardless of confidence; skipped/error results never escalate
+//     (brief: no silent fallbacks — a missing verdict is not a pass).
+//
+// Intentionally NOT in this file:
+//   - Actual escalation to a stronger model (issue #6, ladder/max).
+//   - Chorus dispatch (issue #8, stub only in MVP).
+//   - Streaming-body handling (ADR-0013: orchestrator is skipped for
+//     streams; the pipeline decides that upstream of this function).
+
+import { collectHardSignals } from './hard-signals.js';
+import type {
+  LlmVerdict,
+  Orchestrator,
+  OrchestratorConfig,
+  OrchestratorDecision,
+  OrchestratorInput,
+  Signal,
+  SignalCategory,
+  SignalWeights,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Noisy-OR aggregation
+// ---------------------------------------------------------------------------
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+/**
+ * Aggregate signals via weighted noisy-OR:
+ *   P(inadequate) = 1 - prod(1 - weight[cat] * confidence)
+ * Returns a value in [0, 1]. Signals whose weight is 0 contribute
+ * nothing (their category is effectively disabled).
+ */
+export function aggregateSignals(
+  signals: readonly Signal[],
+  weights: SignalWeights,
+): number {
+  let product = 1;
+  for (const signal of signals) {
+    const w = clamp01(weights[signal.category]);
+    const c = clamp01(signal.confidence);
+    product *= 1 - w * c;
+  }
+  return clamp01(1 - product);
+}
+
+// ---------------------------------------------------------------------------
+// Verdict gating
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true iff the orchestrator should invoke the LLM-critic given
+ * the hard-signal aggregate. Per ADR-0010 the critic runs only inside
+ * the configured grey band `[lower, upper)`. Outside the band it is
+ * either redundant (aggregate already escalates) or wasteful
+ * (aggregate is confidently below threshold).
+ */
+function aggregateInGreyBand(
+  aggregate: number,
+  greyBand: readonly [number, number],
+): boolean {
+  const lower = greyBand[0];
+  const upper = greyBand[1];
+  return aggregate >= lower && aggregate < upper;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export const runOrchestrator: Orchestrator = async (
+  input: OrchestratorInput,
+  config: OrchestratorConfig,
+): Promise<OrchestratorDecision> => {
+  const detectorInput = {
+    response: input.response,
+    userPrompt: input.userPrompt,
+    ...(input.finishReason !== undefined ? { finishReason: input.finishReason } : {}),
+    ...(input.locale !== undefined ? { locale: input.locale } : {}),
+  };
+  const signals = collectHardSignals(detectorInput);
+  const aggregate = aggregateSignals(signals, config.weights);
+
+  // Hard-signal track: escalate immediately when the pool crosses the
+  // threshold. No need to invoke the LLM-critic — the evidence is already
+  // sufficient.
+  if (aggregate >= config.threshold) {
+    return { kind: 'escalate', reason: 'hard_signals', signals, aggregate };
+  }
+
+  // LLM-critic track: only when configured AND aggregate lands in the
+  // grey band.
+  if (config.llmCritic !== undefined && aggregateInGreyBand(aggregate, config.greyBand)) {
+    const result = await config.llmCritic.run(
+      {
+        response: input.response,
+        userPrompt: input.userPrompt,
+        ...(input.locale !== undefined ? { locale: input.locale } : {}),
+      },
+      config.llmCritic.config,
+    );
+
+    if (result.kind === 'verdict') {
+      const v: LlmVerdict = result.verdict;
+      // Per ADR-0011: pass verdicts never escalate; fail verdicts
+      // escalate only when confidence clears the same threshold the
+      // hard-signal pool uses. Skipped/error verdicts (not handled
+      // here) fall through to pass — per brief, "no silent fallback"
+      // means we don't invent a fail from a missing verdict.
+      if (v.verdict === 'fail' && v.confidence >= config.threshold) {
+        return {
+          kind: 'escalate',
+          reason: 'llm_verdict',
+          signals,
+          aggregate,
+          verdict: v,
+        };
+      }
+      return { kind: 'pass', signals, aggregate, verdict: v };
+    }
+    // result.kind is 'skipped' or 'error'; fall through to pass
+    // without a verdict — the transparency layer and audit log can
+    // show the signals and aggregate, and the absence of a verdict is
+    // itself signal-bearing information they can render.
+  }
+
+  return { kind: 'pass', signals, aggregate };
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers exported for testing
+// ---------------------------------------------------------------------------
+
+/** @internal — exposed for unit tests only. */
+export const __internal = {
+  aggregateSignals,
+  aggregateInGreyBand,
+  clamp01,
+};
+
+/** Re-export for convenience so callers importing the orchestrator get
+ * the category list from one place. */
+export type { SignalCategory };

--- a/src/critic/orchestrator.ts
+++ b/src/critic/orchestrator.ts
@@ -48,10 +48,7 @@ function clamp01(x: number): number {
  * Returns a value in [0, 1]. Signals whose weight is 0 contribute
  * nothing (their category is effectively disabled).
  */
-export function aggregateSignals(
-  signals: readonly Signal[],
-  weights: SignalWeights,
-): number {
+export function aggregateSignals(signals: readonly Signal[], weights: SignalWeights): number {
   let product = 1;
   for (const signal of signals) {
     const w = clamp01(weights[signal.category]);
@@ -72,10 +69,7 @@ export function aggregateSignals(
  * either redundant (aggregate already escalates) or wasteful
  * (aggregate is confidently below threshold).
  */
-function aggregateInGreyBand(
-  aggregate: number,
-  greyBand: readonly [number, number],
-): boolean {
+function aggregateInGreyBand(aggregate: number, greyBand: readonly [number, number]): boolean {
   const lower = greyBand[0];
   const upper = greyBand[1];
   return aggregate >= lower && aggregate < upper;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -26,11 +26,7 @@
 
 import { forwardChatCompletion } from './proxy.js';
 import { runOrchestrator } from './critic/orchestrator.js';
-import type {
-  OrchestratorConfig,
-  OrchestratorDecision,
-  ProxyTarget,
-} from './types.js';
+import type { OrchestratorConfig, OrchestratorDecision, ProxyTarget } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Request inspection
@@ -169,17 +165,11 @@ function annotateResponse(response: Response, decision: OrchestratorDecision): R
       headers.set('x-turbocharger-decision', 'pass');
       headers.set('x-turbocharger-aggregate', decision.aggregate.toFixed(3));
       if (decision.signals.length > 0) {
-        headers.set(
-          'x-turbocharger-signals',
-          decision.signals.map((s) => s.category).join(','),
-        );
+        headers.set('x-turbocharger-signals', decision.signals.map((s) => s.category).join(','));
       }
       if (decision.verdict !== undefined) {
         headers.set('x-turbocharger-verdict', decision.verdict.verdict);
-        headers.set(
-          'x-turbocharger-verdict-confidence',
-          decision.verdict.confidence.toFixed(3),
-        );
+        headers.set('x-turbocharger-verdict-confidence', decision.verdict.confidence.toFixed(3));
       }
       break;
     }
@@ -188,17 +178,11 @@ function annotateResponse(response: Response, decision: OrchestratorDecision): R
       headers.set('x-turbocharger-reason', decision.reason);
       headers.set('x-turbocharger-aggregate', decision.aggregate.toFixed(3));
       if (decision.signals.length > 0) {
-        headers.set(
-          'x-turbocharger-signals',
-          decision.signals.map((s) => s.category).join(','),
-        );
+        headers.set('x-turbocharger-signals', decision.signals.map((s) => s.category).join(','));
       }
       if (decision.verdict !== undefined) {
         headers.set('x-turbocharger-verdict', decision.verdict.verdict);
-        headers.set(
-          'x-turbocharger-verdict-confidence',
-          decision.verdict.confidence.toFixed(3),
-        );
+        headers.set('x-turbocharger-verdict-confidence', decision.verdict.confidence.toFixed(3));
       }
       break;
     }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,313 @@
+// Pipeline: forwards a chat/completions request via the proxy, then runs
+// the orchestrator against the response body to produce an
+// {@link OrchestratorDecision}. Returns the (possibly annotated)
+// response and the decision; the caller (server.ts) emits headers and
+// the log line.
+//
+// Scope (v0.1, issue #5):
+//   - Non-streamed `application/json` responses with 2xx status are
+//     evaluated. The body is buffered, the orchestrator runs against
+//     the assembled content, and the decision is surfaced via
+//     X-Turbocharger-* headers on the response that is returned to the
+//     client. Body bytes are unchanged.
+//   - Streamed responses (`stream: true` or `text/event-stream`) are
+//     skipped per ADR-0013. The orchestrator returns
+//     { kind: 'skipped', reason: 'streaming' }; the response is
+//     forwarded unchanged and no decision headers are added.
+//   - Non-2xx responses are skipped (the downstream already signalled
+//     failure; the critic has no role), as are non-JSON bodies.
+//
+// Intentionally NOT in this file:
+//   - The actual escalation machinery. Issue #5 only decides; issue #6
+//     (ladder/max) acts on the decision.
+//   - Config loading. The pipeline takes an OrchestratorConfig as
+//     input; how that config is built (env, YAML, Zod schema) is
+//     issue #11.
+
+import { forwardChatCompletion } from './proxy.js';
+import { runOrchestrator } from './critic/orchestrator.js';
+import type {
+  OrchestratorConfig,
+  OrchestratorDecision,
+  ProxyTarget,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Request inspection
+// ---------------------------------------------------------------------------
+
+interface ParsedRequest {
+  readonly stream: boolean;
+  readonly userPrompt: string;
+  readonly locale?: string;
+}
+
+/**
+ * Inspect the client's chat/completions request body to decide whether
+ * streaming was requested, extract the last user message for the
+ * orchestrator, and pick up an optional locale hint.
+ *
+ * The original Request is not consumed: the caller owns the original,
+ * we clone for inspection so that {@link forwardChatCompletion} can
+ * still read the body bytes.
+ */
+async function parseClientRequest(request: Request): Promise<ParsedRequest> {
+  let parsed: unknown = null;
+  try {
+    parsed = await request.clone().json();
+  } catch {
+    // Not JSON, or malformed. Proceed with safe defaults; the downstream
+    // will return an HTTP error and the orchestrator will skip it.
+  }
+
+  const stream = readBoolean(parsed, 'stream');
+  const userPrompt = extractUserPrompt(parsed);
+  const locale = readString(parsed, 'locale') ?? readHeaderLocale(request);
+
+  return {
+    stream,
+    userPrompt,
+    ...(locale !== undefined ? { locale } : {}),
+  };
+}
+
+function readBoolean(obj: unknown, key: string): boolean {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const v = (obj as Record<string, unknown>)[key];
+  return typeof v === 'boolean' ? v : false;
+}
+
+function readString(obj: unknown, key: string): string | undefined {
+  if (typeof obj !== 'object' || obj === null) return undefined;
+  const v = (obj as Record<string, unknown>)[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function readHeaderLocale(request: Request): string | undefined {
+  const hdr = request.headers.get('accept-language');
+  if (hdr === null || hdr.length === 0) return undefined;
+  // Simplest possible parse: take the first tag, strip any q-factor.
+  const first = hdr.split(',')[0];
+  if (first === undefined) return undefined;
+  const tag = first.split(';')[0]?.trim();
+  return tag !== undefined && tag.length > 0 ? tag : undefined;
+}
+
+function extractUserPrompt(parsed: unknown): string {
+  if (typeof parsed !== 'object' || parsed === null) return '';
+  const messages = (parsed as Record<string, unknown>)['messages'];
+  if (!Array.isArray(messages)) return '';
+  // Walk from the end, find the last message with role === 'user'.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (typeof msg !== 'object' || msg === null) continue;
+    const role = (msg as Record<string, unknown>)['role'];
+    if (role !== 'user') continue;
+    const content = (msg as Record<string, unknown>)['content'];
+    if (typeof content === 'string') return content;
+    // OpenAI supports array-of-parts content; extract text parts only.
+    if (Array.isArray(content)) {
+      const parts: string[] = [];
+      for (const part of content) {
+        if (typeof part === 'object' && part !== null) {
+          const text = (part as Record<string, unknown>)['text'];
+          if (typeof text === 'string') parts.push(text);
+        }
+      }
+      return parts.join('\n');
+    }
+    return '';
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Response inspection
+// ---------------------------------------------------------------------------
+
+interface ParsedResponse {
+  readonly content: string;
+  readonly finishReason?: string;
+}
+
+/** Extract the assistant content and finish_reason from a non-streamed
+ * chat/completions JSON body. Returns empty strings for anything
+ * unexpected — the orchestrator's empty/short detector catches those
+ * naturally. */
+function parseChatCompletionBody(json: unknown): ParsedResponse {
+  if (typeof json !== 'object' || json === null) return { content: '' };
+  const choices = (json as Record<string, unknown>)['choices'];
+  if (!Array.isArray(choices) || choices.length === 0) return { content: '' };
+  const first = choices[0];
+  if (typeof first !== 'object' || first === null) return { content: '' };
+  const message = (first as Record<string, unknown>)['message'];
+  const finishReason = (first as Record<string, unknown>)['finish_reason'];
+  const rawContent =
+    typeof message === 'object' && message !== null
+      ? (message as Record<string, unknown>)['content']
+      : undefined;
+  const content = typeof rawContent === 'string' ? rawContent : '';
+  return {
+    content,
+    ...(typeof finishReason === 'string' ? { finishReason } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Header annotation
+// ---------------------------------------------------------------------------
+
+/** Attach X-Turbocharger-* headers describing the decision. Header
+ * values never contain newlines or control characters. The reason
+ * strings from individual signals are condensed to a comma-separated
+ * category list to keep header sizes modest. */
+function annotateResponse(response: Response, decision: OrchestratorDecision): Response {
+  const headers = new Headers(response.headers);
+
+  switch (decision.kind) {
+    case 'pass': {
+      headers.set('x-turbocharger-decision', 'pass');
+      headers.set('x-turbocharger-aggregate', decision.aggregate.toFixed(3));
+      if (decision.signals.length > 0) {
+        headers.set(
+          'x-turbocharger-signals',
+          decision.signals.map((s) => s.category).join(','),
+        );
+      }
+      if (decision.verdict !== undefined) {
+        headers.set('x-turbocharger-verdict', decision.verdict.verdict);
+        headers.set(
+          'x-turbocharger-verdict-confidence',
+          decision.verdict.confidence.toFixed(3),
+        );
+      }
+      break;
+    }
+    case 'escalate': {
+      headers.set('x-turbocharger-decision', 'escalate');
+      headers.set('x-turbocharger-reason', decision.reason);
+      headers.set('x-turbocharger-aggregate', decision.aggregate.toFixed(3));
+      if (decision.signals.length > 0) {
+        headers.set(
+          'x-turbocharger-signals',
+          decision.signals.map((s) => s.category).join(','),
+        );
+      }
+      if (decision.verdict !== undefined) {
+        headers.set('x-turbocharger-verdict', decision.verdict.verdict);
+        headers.set(
+          'x-turbocharger-verdict-confidence',
+          decision.verdict.confidence.toFixed(3),
+        );
+      }
+      break;
+    }
+    case 'skipped': {
+      headers.set('x-turbocharger-decision', 'skipped');
+      headers.set('x-turbocharger-reason', decision.reason);
+      break;
+    }
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export interface PipelineResult {
+  readonly response: Response;
+  readonly decision: OrchestratorDecision;
+}
+
+/**
+ * Run the full pipeline: forward the request, then run the orchestrator
+ * against the response if it is evaluable (non-streamed JSON, 2xx).
+ * Returns the (possibly annotated) response and the decision.
+ *
+ * Streams and error responses skip the orchestrator by design:
+ * - Streaming responses (ADR-0013) are not inspected in v0.1.
+ * - Non-2xx responses are passed through with no critic involvement.
+ */
+export async function runPipeline(
+  request: Request,
+  target: ProxyTarget,
+  orchestratorConfig: OrchestratorConfig,
+): Promise<PipelineResult> {
+  const parsed = await parseClientRequest(request);
+  const downstream = await forwardChatCompletion(request, target);
+
+  // Short-circuit paths that bypass the orchestrator entirely. The
+  // response body is already a ReadableStream in these cases; we must
+  // not consume it, or the client will see an empty body.
+  if (parsed.stream) {
+    const decision: OrchestratorDecision = { kind: 'skipped', reason: 'streaming' };
+    return { response: annotateResponse(downstream, decision), decision };
+  }
+  if (!downstream.ok) {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_ok_status',
+      detail: `${downstream.status} ${downstream.statusText}`,
+    };
+    return { response: annotateResponse(downstream, decision), decision };
+  }
+
+  const contentType = downstream.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_json_content_type',
+      detail: contentType,
+    };
+    return { response: annotateResponse(downstream, decision), decision };
+  }
+
+  // Buffer the response body. Chat-completion JSON payloads are small;
+  // the streaming case above handles the one that could be large.
+  const bodyText = await downstream.text();
+
+  let bodyJson: unknown;
+  try {
+    bodyJson = JSON.parse(bodyText);
+  } catch {
+    // Downstream claimed JSON but produced something we can't parse.
+    // Forward the body bytes unchanged and skip the orchestrator.
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_json_content_type',
+      detail: 'JSON parse failure',
+    };
+    const reconstituted = new Response(bodyText, {
+      status: downstream.status,
+      statusText: downstream.statusText,
+      headers: downstream.headers,
+    });
+    return { response: annotateResponse(reconstituted, decision), decision };
+  }
+
+  const assistant = parseChatCompletionBody(bodyJson);
+  const decision = await runOrchestrator(
+    {
+      response: assistant.content,
+      userPrompt: parsed.userPrompt,
+      ...(assistant.finishReason !== undefined ? { finishReason: assistant.finishReason } : {}),
+      ...(parsed.locale !== undefined ? { locale: parsed.locale } : {}),
+    },
+    orchestratorConfig,
+  );
+
+  // Rebuild the response with the original body text (so the client
+  // gets the exact bytes the downstream sent).
+  const reconstituted = new Response(bodyText, {
+    status: downstream.status,
+    statusText: downstream.statusText,
+    headers: downstream.headers,
+  });
+  return { response: annotateResponse(reconstituted, decision), decision };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,11 @@
 // OpenAI-compatible HTTP server entry.
 //
-// Issue #2 scope: a minimal Hono app exposing POST /v1/chat/completions that
-// pass-through-forwards to a configured downstream target (see proxy.ts) and
-// emits one structured log line per request. Critic / escalation /
-// transparency hooks land in later issues.
+// Issue #2 introduced the pass-through proxy. Issue #5 adds an optional
+// orchestrator pipeline in front of the proxy: when `pipelineConfig` is
+// present in {@link AppDeps}, the request flows through
+// {@link runPipeline} instead of directly through
+// {@link forwardChatCompletion}, and the resulting decision is surfaced
+// in response headers and in the per-request log line.
 
 import { fileURLToPath } from 'node:url';
 
@@ -11,13 +13,38 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 
 import { loadEnvConfig } from './config/env.js';
+import { runPipeline } from './pipeline.js';
 import { forwardChatCompletion } from './proxy.js';
-import type { AppConfig, ProxyTarget, RequestLogger } from './types.js';
+import type {
+  AppConfig,
+  OrchestratorConfig,
+  OrchestratorDecision,
+  ProxyTarget,
+  RequestLogEntry,
+  RequestLogger,
+} from './types.js';
 
 export interface AppDeps {
   readonly proxyTarget: ProxyTarget;
   /** Optional logger override; defaults to one JSON object per line on stderr. */
   readonly logger?: RequestLogger;
+  /**
+   * Optional orchestrator configuration. When present, the server runs
+   * the full {@link runPipeline} (proxy + orchestrator) and adds
+   * X-Turbocharger-* response headers and a decision field to the log
+   * line. When absent, the server falls back to the pass-through proxy
+   * behaviour from issue #2.
+   */
+  readonly orchestratorConfig?: OrchestratorConfig;
+}
+
+/**
+ * Per-request log entry with an optional orchestrator decision field.
+ * Extends {@link RequestLogEntry} without modifying its narrow shape.
+ */
+export interface DecisionLogEntry extends RequestLogEntry {
+  readonly decision?: OrchestratorDecision['kind'];
+  readonly decision_reason?: string;
 }
 
 const defaultLogger: RequestLogger = (entry) => {
@@ -36,7 +63,18 @@ export function createApp(deps: AppDeps): Hono {
   app.post('/v1/chat/completions', async (c) => {
     const start = Date.now();
     let status = 0;
+    let decisionKind: OrchestratorDecision['kind'] | undefined;
+    let decisionReason: string | undefined;
     try {
+      if (deps.orchestratorConfig !== undefined) {
+        const result = await runPipeline(c.req.raw, deps.proxyTarget, deps.orchestratorConfig);
+        status = result.response.status;
+        decisionKind = result.decision.kind;
+        if (result.decision.kind === 'escalate' || result.decision.kind === 'skipped') {
+          decisionReason = result.decision.reason;
+        }
+        return result.response;
+      }
       const downstream = await forwardChatCompletion(c.req.raw, deps.proxyTarget);
       status = downstream.status;
       return downstream;
@@ -59,13 +97,16 @@ export function createApp(deps: AppDeps): Hono {
         502,
       );
     } finally {
-      log({
+      const entry: DecisionLogEntry = {
         ts: new Date().toISOString(),
         method: c.req.method,
         path: new URL(c.req.url).pathname,
         status,
         latency_ms: Date.now() - start,
-      });
+        ...(decisionKind !== undefined ? { decision: decisionKind } : {}),
+        ...(decisionReason !== undefined ? { decision_reason: decisionReason } : {}),
+      };
+      log(entry);
     }
   });
 
@@ -83,12 +124,21 @@ export interface RunningServer {
  * Start the sidecar HTTP server on the configured port. Returns a handle
  * with a `close()` for graceful shutdown.
  */
-export function startServer(config: AppConfig = loadEnvConfig()): RunningServer {
+export function startServer(
+  config: AppConfig = loadEnvConfig(),
+  deps?: Omit<AppDeps, 'proxyTarget'>,
+): RunningServer {
   const proxyTarget: ProxyTarget = {
     baseUrl: config.downstreamBaseUrl,
     ...(config.downstreamApiKey !== undefined ? { apiKey: config.downstreamApiKey } : {}),
   };
-  const app = createApp({ proxyTarget });
+  const app = createApp({
+    proxyTarget,
+    ...(deps?.logger !== undefined ? { logger: deps.logger } : {}),
+    ...(deps?.orchestratorConfig !== undefined
+      ? { orchestratorConfig: deps.orchestratorConfig }
+      : {}),
+  });
 
   const server = serve({
     fetch: app.fetch,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@
 // truth so that proxy / critic / escalation / transparency stay structurally
 // consistent. Issue #2 introduces the minimal surface needed for the
 // pass-through proxy; issue #3 adds the hard-signal detection surface;
-// issue #4 adds the LLM-critic surface; later issues extend further.
+// issue #4 adds the LLM-critic surface; issue #5 adds the orchestrator and
+// pipeline surfaces; later issues extend further.
 
 /**
  * Effective configuration for a running sidecar process.
@@ -213,3 +214,100 @@ export type LlmCritic = (
   input: LlmCriticInput,
   config: LlmCriticConfig,
 ) => Promise<LlmCriticResult>;
+
+// ---------------------------------------------------------------------------
+// Orchestrator and pipeline (issue #5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-category weight for the hard-signal noisy-OR aggregation. Each
+ * weight is a multiplier applied to the signal's confidence before the
+ * noisy-OR combination:
+ * `P(inadequate) = 1 - prod(1 - weight_i * confidence_i)`.
+ * A weight of `0` disables the category. Weights outside [0, 1] are
+ * clamped by the aggregator.
+ */
+export type SignalWeights = Readonly<Record<SignalCategory, number>>;
+
+/**
+ * Configuration passed to {@link runOrchestrator}. No Zod validation
+ * yet — issue #11 introduces the full config schema. Sensible defaults
+ * are documented but the orchestrator does not supply them; callers
+ * must construct a complete config.
+ */
+export interface OrchestratorConfig {
+  /**
+   * Escalation threshold: when the noisy-OR aggregate crosses this (or
+   * the LLM-critic's fail confidence does, per ADR-0011), the decision
+   * is `escalate`. Default recommendation: 0.6 (see ADR-0006).
+   */
+  readonly threshold: number;
+  /** Per-category weights for the hard-signal aggregator. */
+  readonly weights: SignalWeights;
+  /**
+   * Grey band [lower, upper) in which the LLM-critic, if configured,
+   * is invoked. Outside the band, the critic is skipped. Per ADR-0010
+   * the default is `[0.30, 0.60)`.
+   */
+  readonly greyBand: readonly [number, number];
+  /**
+   * Optional LLM-critic invocation. When absent, the orchestrator runs
+   * hard-signals only. When present, the callable is invoked when the
+   * noisy-OR aggregate lands in the grey band.
+   */
+  readonly llmCritic?: {
+    readonly run: LlmCritic;
+    readonly config: LlmCriticConfig;
+  };
+}
+
+/**
+ * Input passed to {@link runOrchestrator}. Same fields as
+ * {@link DetectorInput}, plus the finish_reason pass-through.
+ */
+export interface OrchestratorInput {
+  readonly response: string;
+  readonly userPrompt: string;
+  readonly finishReason?: string;
+  readonly locale?: string;
+}
+
+/**
+ * Discriminated decision produced by {@link runOrchestrator}. The kind
+ * drives what the pipeline does next:
+ *
+ * - `pass`: no escalation. Response is forwarded unchanged.
+ * - `escalate`: adequacy fell short. Escalation machinery (issue #6)
+ *   will act on this; in v0.1 it is only reported via headers and log.
+ * - `skipped`: orchestrator was not able to run (e.g. streaming response
+ *   per ADR-0013). Pipeline forwards unchanged and logs the skip.
+ *
+ * The `signals`, `aggregate`, and `verdict` fields let the transparency
+ * layer (ADR-0007) and the audit log render a rich report without
+ * re-running anything.
+ */
+export type OrchestratorDecision =
+  | {
+      readonly kind: 'pass';
+      readonly signals: readonly Signal[];
+      readonly aggregate: number;
+      readonly verdict?: LlmVerdict;
+    }
+  | {
+      readonly kind: 'escalate';
+      readonly reason: 'hard_signals' | 'llm_verdict';
+      readonly signals: readonly Signal[];
+      readonly aggregate: number;
+      readonly verdict?: LlmVerdict;
+    }
+  | {
+      readonly kind: 'skipped';
+      readonly reason: 'streaming' | 'non_ok_status' | 'non_json_content_type';
+      readonly detail?: string;
+    };
+
+/** Signature of the orchestrator callable. */
+export type Orchestrator = (
+  input: OrchestratorInput,
+  config: OrchestratorConfig,
+) => Promise<OrchestratorDecision>;

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { aggregateSignals, runOrchestrator } from '../src/critic/index.js';
+import { __internal } from '../src/critic/orchestrator.js';
+import type {
+  LlmCritic,
+  LlmCriticConfig,
+  OrchestratorConfig,
+  Signal,
+  SignalCategory,
+  SignalWeights,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const { aggregateInGreyBand, clamp01 } = __internal;
+
+const DEFAULT_WEIGHTS: SignalWeights = {
+  refusal: 1,
+  truncation: 1,
+  repetition: 1,
+  empty: 1,
+  tool_error: 1,
+  syntax_error: 1,
+};
+
+function makeConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    threshold: 0.6,
+    weights: DEFAULT_WEIGHTS,
+    greyBand: [0.3, 0.6] as const,
+    ...overrides,
+  };
+}
+
+function signal(category: SignalCategory, confidence: number, reason = 'test'): Signal {
+  return { category, confidence, reason };
+}
+
+/** Build a minimal LLM-critic stub returning a fixed result. */
+function stubCritic(
+  result: Awaited<ReturnType<LlmCritic>>,
+): OrchestratorConfig['llmCritic'] {
+  const run: LlmCritic = vi.fn(async () => result) as unknown as LlmCritic;
+  const config: LlmCriticConfig = {
+    baseUrl: 'http://critic.test/v1',
+    model: 'test',
+  };
+  return { run, config };
+}
+
+// ---------------------------------------------------------------------------
+// clamp01
+// ---------------------------------------------------------------------------
+
+describe('clamp01', () => {
+  it('clamps values below 0', () => {
+    expect(clamp01(-0.5)).toBe(0);
+  });
+  it('clamps values above 1', () => {
+    expect(clamp01(1.5)).toBe(1);
+  });
+  it('passes through in-range values', () => {
+    expect(clamp01(0.42)).toBeCloseTo(0.42, 5);
+  });
+  it('maps NaN to 0', () => {
+    expect(clamp01(Number.NaN)).toBe(0);
+  });
+  it('maps Infinity to 0', () => {
+    expect(clamp01(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateSignals — noisy-OR combiner
+// ---------------------------------------------------------------------------
+
+describe('aggregateSignals', () => {
+  it('returns 0 when there are no signals', () => {
+    expect(aggregateSignals([], DEFAULT_WEIGHTS)).toBe(0);
+  });
+
+  it('matches confidence when a single signal fires at weight 1', () => {
+    expect(aggregateSignals([signal('refusal', 0.8)], DEFAULT_WEIGHTS)).toBeCloseTo(0.8, 5);
+  });
+
+  it('scales confidence by weight', () => {
+    const weights: SignalWeights = { ...DEFAULT_WEIGHTS, refusal: 0.5 };
+    // noisy-OR with a single signal at w*c = 0.4 → aggregate = 0.4.
+    expect(aggregateSignals([signal('refusal', 0.8)], weights)).toBeCloseTo(0.4, 5);
+  });
+
+  it('produces an aggregate strictly greater than each individual signal', () => {
+    const signals = [signal('refusal', 0.4), signal('truncation', 0.4), signal('repetition', 0.4)];
+    const agg = aggregateSignals(signals, DEFAULT_WEIGHTS);
+    // 1 - (1-0.4)^3 = 1 - 0.216 = 0.784
+    expect(agg).toBeCloseTo(0.784, 3);
+    expect(agg).toBeGreaterThan(0.4);
+  });
+
+  it('disables a category when its weight is 0', () => {
+    const weights: SignalWeights = { ...DEFAULT_WEIGHTS, refusal: 0 };
+    const signals = [signal('refusal', 0.95), signal('empty', 0.4)];
+    // Only the empty signal contributes at weight 1.
+    expect(aggregateSignals(signals, weights)).toBeCloseTo(0.4, 5);
+  });
+
+  it('clamps out-of-range confidences and weights', () => {
+    // Confidence 1.5 clamps to 1, weight 1 clamps to 1 → product factor 0.
+    // Aggregate = 1 - 0 = 1.
+    expect(aggregateSignals([signal('refusal', 1.5)], DEFAULT_WEIGHTS)).toBe(1);
+  });
+
+  it('stays within [0, 1] for many concurrent signals at high confidence', () => {
+    const signals: Signal[] = [
+      signal('refusal', 0.95),
+      signal('truncation', 0.9),
+      signal('repetition', 0.8),
+      signal('empty', 0.9),
+      signal('tool_error', 0.95),
+      signal('syntax_error', 0.85),
+    ];
+    const agg = aggregateSignals(signals, DEFAULT_WEIGHTS);
+    expect(agg).toBeGreaterThanOrEqual(0);
+    expect(agg).toBeLessThanOrEqual(1);
+    // Six high-confidence signals should drive the aggregate very close to 1.
+    expect(agg).toBeGreaterThan(0.99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateInGreyBand
+// ---------------------------------------------------------------------------
+
+describe('aggregateInGreyBand', () => {
+  it('returns true at the lower bound', () => {
+    expect(aggregateInGreyBand(0.3, [0.3, 0.6])).toBe(true);
+  });
+  it('returns false at the upper bound (exclusive)', () => {
+    expect(aggregateInGreyBand(0.6, [0.3, 0.6])).toBe(false);
+  });
+  it('returns false below the band', () => {
+    expect(aggregateInGreyBand(0.29, [0.3, 0.6])).toBe(false);
+  });
+  it('returns false above the band', () => {
+    expect(aggregateInGreyBand(0.9, [0.3, 0.6])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runOrchestrator — end-to-end
+// ---------------------------------------------------------------------------
+
+describe('runOrchestrator', () => {
+  it('passes on a clean response below the grey band, without invoking the critic', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'fail', confidence: 0.9, reason: 'unexpected' },
+    });
+    const decision = await runOrchestrator(
+      {
+        response: 'Here is a perfectly reasonable and helpful answer to your question.',
+        userPrompt: 'What time is it?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('pass');
+    expect(critic!.run).not.toHaveBeenCalled();
+  });
+
+  it('escalates on hard-signal evidence without invoking the critic', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'pass', confidence: 0.9, reason: 'looks ok' },
+    });
+    // Explicit refusal text drives the refusal detector above 0.9; the
+    // aggregate exceeds the default 0.6 threshold on hard signals alone.
+    const decision = await runOrchestrator(
+      {
+        response: "I'm sorry, but I cannot help with that request.",
+        userPrompt: 'Please explain how to do it.',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('escalate');
+    if (decision.kind === 'escalate') {
+      expect(decision.reason).toBe('hard_signals');
+      expect(decision.signals.some((s) => s.category === 'refusal')).toBe(true);
+    }
+    expect(critic!.run).not.toHaveBeenCalled();
+  });
+
+  it('invokes the critic when the aggregate lands in the grey band', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'fail', confidence: 0.8, reason: 'too short' },
+    });
+    // A single mid-confidence hedge fires one 0.4 refusal signal.
+    // Noisy-OR with a single 0.4 signal → aggregate 0.4, inside [0.3, 0.6).
+    const decision = await runOrchestrator(
+      {
+        response: 'I would advise caution when interpreting these numbers because data is thin.',
+        userPrompt: 'Is the trend positive?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(critic!.run).toHaveBeenCalledTimes(1);
+    expect(decision.kind).toBe('escalate');
+    if (decision.kind === 'escalate') {
+      expect(decision.reason).toBe('llm_verdict');
+      expect(decision.verdict?.verdict).toBe('fail');
+    }
+  });
+
+  it('passes with the verdict attached when the critic says pass in the grey band', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'pass', confidence: 0.9, reason: 'adequate' },
+    });
+    const decision = await runOrchestrator(
+      {
+        response: 'I would advise caution when interpreting these numbers because data is thin.',
+        userPrompt: 'Is the trend positive?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('pass');
+    if (decision.kind === 'pass') {
+      expect(decision.verdict?.verdict).toBe('pass');
+    }
+  });
+
+  it('passes when the critic fail verdict has low confidence (below threshold)', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'fail', confidence: 0.3, reason: 'uncertain' },
+    });
+    const decision = await runOrchestrator(
+      {
+        response: 'I would advise caution when interpreting these numbers because data is thin.',
+        userPrompt: 'Is the trend positive?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('pass');
+  });
+
+  it('passes without a verdict when the critic is skipped (budget exceeded)', async () => {
+    const critic = stubCritic({ kind: 'skipped', reason: 'over_budget' });
+    const decision = await runOrchestrator(
+      {
+        response: 'I would advise caution when interpreting these numbers because data is thin.',
+        userPrompt: 'Is the trend positive?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('pass');
+    if (decision.kind === 'pass') {
+      expect(decision.verdict).toBeUndefined();
+    }
+  });
+
+  it('passes without a verdict when the critic errors out', async () => {
+    const critic = stubCritic({ kind: 'error', reason: 'network', detail: 'connection refused' });
+    const decision = await runOrchestrator(
+      {
+        response: 'I would advise caution when interpreting these numbers because data is thin.',
+        userPrompt: 'Is the trend positive?',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(decision.kind).toBe('pass');
+    if (decision.kind === 'pass') {
+      expect(decision.verdict).toBeUndefined();
+    }
+  });
+
+  it('does not invoke the critic outside the grey band even when configured', async () => {
+    const critic = stubCritic({
+      kind: 'verdict',
+      verdict: { verdict: 'fail', confidence: 0.9, reason: 'x' },
+    });
+    // Clean response → aggregate well below the lower grey bound.
+    await runOrchestrator(
+      {
+        response: 'This is a clear, complete, helpful answer with specifics and context.',
+        userPrompt: 'Explain that briefly.',
+      },
+      makeConfig({ llmCritic: critic }),
+    );
+    expect(critic!.run).not.toHaveBeenCalled();
+  });
+
+  it('forwards finishReason and locale to the hard-signal detectors', async () => {
+    // finish_reason: 'length' without a natural terminator fires the
+    // truncation detector at 0.9 → well above the default threshold.
+    const decision = await runOrchestrator(
+      {
+        response: 'The answer ends mid-thou',
+        userPrompt: 'Explain.',
+        finishReason: 'length',
+      },
+      makeConfig(),
+    );
+    expect(decision.kind).toBe('escalate');
+    if (decision.kind === 'escalate') {
+      expect(decision.signals.some((s) => s.category === 'truncation')).toBe(true);
+    }
+  });
+});

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -39,10 +39,13 @@ function signal(category: SignalCategory, confidence: number, reason = 'test'): 
   return { category, confidence, reason };
 }
 
-/** Build a minimal LLM-critic stub returning a fixed result. */
-function stubCritic(
-  result: Awaited<ReturnType<LlmCritic>>,
-): OrchestratorConfig['llmCritic'] {
+/** Build a minimal LLM-critic stub returning a fixed result. Returns a
+ * concrete (non-undefined) object so it can always be spread into an
+ * OrchestratorConfig under exactOptionalPropertyTypes. */
+function stubCritic(result: Awaited<ReturnType<LlmCritic>>): {
+  readonly run: LlmCritic;
+  readonly config: LlmCriticConfig;
+} {
   const run: LlmCritic = vi.fn(async () => result) as unknown as LlmCritic;
   const config: LlmCriticConfig = {
     baseUrl: 'http://critic.test/v1',
@@ -167,7 +170,7 @@ describe('runOrchestrator', () => {
       makeConfig({ llmCritic: critic }),
     );
     expect(decision.kind).toBe('pass');
-    expect(critic!.run).not.toHaveBeenCalled();
+    expect(critic.run).not.toHaveBeenCalled();
   });
 
   it('escalates on hard-signal evidence without invoking the critic', async () => {
@@ -189,7 +192,7 @@ describe('runOrchestrator', () => {
       expect(decision.reason).toBe('hard_signals');
       expect(decision.signals.some((s) => s.category === 'refusal')).toBe(true);
     }
-    expect(critic!.run).not.toHaveBeenCalled();
+    expect(critic.run).not.toHaveBeenCalled();
   });
 
   it('invokes the critic when the aggregate lands in the grey band', async () => {
@@ -206,7 +209,7 @@ describe('runOrchestrator', () => {
       },
       makeConfig({ llmCritic: critic }),
     );
-    expect(critic!.run).toHaveBeenCalledTimes(1);
+    expect(critic.run).toHaveBeenCalledTimes(1);
     expect(decision.kind).toBe('escalate');
     if (decision.kind === 'escalate') {
       expect(decision.reason).toBe('llm_verdict');
@@ -290,7 +293,7 @@ describe('runOrchestrator', () => {
       },
       makeConfig({ llmCritic: critic }),
     );
-    expect(critic!.run).not.toHaveBeenCalled();
+    expect(critic.run).not.toHaveBeenCalled();
   });
 
   it('forwards finishReason and locale to the hard-signal detectors', async () => {

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -1,0 +1,285 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type RunningServer } from '../src/server.js';
+import type {
+  DecisionLogEntry,
+  OrchestratorConfig,
+  SignalWeights,
+} from '../src/types.js';
+
+// Re-declare here because src/server.ts does not re-export DecisionLogEntry
+// via a type-only barrel.
+// NOTE: Keep this in sync with the DecisionLogEntry in src/server.ts.
+type LogEntry = DecisionLogEntry;
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirrors proxy.test.ts for consistency)
+// ---------------------------------------------------------------------------
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  readonly baseUrl: string;
+  setHandler(handler: MockHandler): void;
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      Promise.resolve(handler(req, res, body)).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end(`mock-error: ${String(err)}`);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}/v1`,
+    setHandler(h) {
+      handler = h;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+const DEFAULT_WEIGHTS: SignalWeights = {
+  refusal: 1,
+  truncation: 1,
+  repetition: 1,
+  empty: 1,
+  tool_error: 1,
+  syntax_error: 1,
+};
+
+function makeConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    threshold: 0.6,
+    weights: DEFAULT_WEIGHTS,
+    greyBand: [0.3, 0.6] as const,
+    ...overrides,
+  };
+}
+
+function buildChatCompletionBody(content: string, finishReason = 'stop'): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: finishReason,
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('pipeline', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: LogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as LogEntry);
+        },
+        orchestratorConfig: makeConfig(),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  it('annotates a pass response with X-Turbocharger-Decision: pass', async () => {
+    const body = buildChatCompletionBody(
+      'Here is a clear, complete, helpful answer with concrete details and context.',
+    );
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'Explain it briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    const aggregate = res.headers.get('x-turbocharger-aggregate');
+    expect(aggregate).not.toBeNull();
+    expect(Number(aggregate)).toBeLessThan(0.3);
+    // Body must be byte-for-byte preserved.
+    expect(await res.text()).toBe(body);
+    expect(logs[0]?.decision).toBe('pass');
+  });
+
+  it('annotates an escalate response with reason=hard_signals when a refusal fires', async () => {
+    const body = buildChatCompletionBody("I'm sorry, but I cannot help with that.");
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'Please help with something.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-reason')).toBe('hard_signals');
+    const signalsHeader = res.headers.get('x-turbocharger-signals');
+    expect(signalsHeader).not.toBeNull();
+    expect(signalsHeader!.split(',')).toContain('refusal');
+    expect(await res.text()).toBe(body);
+    expect(logs[0]?.decision).toBe('escalate');
+    expect(logs[0]?.decision_reason).toBe('hard_signals');
+  });
+
+  it('skips streaming responses with decision=skipped, reason=streaming', async () => {
+    // Whatever the mock sends is fine — the pipeline should short-circuit
+    // on the request body's stream: true and not inspect the response.
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.end('data: [DONE]\n\n');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        stream: true,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('skipped');
+    expect(res.headers.get('x-turbocharger-reason')).toBe('streaming');
+    expect(logs[0]?.decision).toBe('skipped');
+    expect(logs[0]?.decision_reason).toBe('streaming');
+  });
+
+  it('skips non-2xx downstream responses with reason=non_ok_status', async () => {
+    mock.setHandler((_req, res) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end('{"error":"server_error"}');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('skipped');
+    expect(res.headers.get('x-turbocharger-reason')).toBe('non_ok_status');
+  });
+
+  it('skips non-JSON downstream responses with reason=non_json_content_type', async () => {
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('plain text body');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('skipped');
+    expect(res.headers.get('x-turbocharger-reason')).toBe('non_json_content_type');
+    expect(await res.text()).toBe('plain text body');
+  });
+
+  it('preserves the original response body bytes on the pass path', async () => {
+    // Use a body with non-ASCII content and a field order that would
+    // round-trip differently through JSON.parse / JSON.stringify, so any
+    // reformatting is visible.
+    const body = JSON.stringify({
+      id: 'chatcmpl-utf',
+      object: 'chat.completion',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'Die Antwort ist klar, vollständig und enthält Details: ä-ö-ü-ß-€.',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-mini',
+        messages: [{ role: 'user', content: 'Erkläre es kurz.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(body);
+  });
+});

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -3,16 +3,10 @@ import type { AddressInfo } from 'node:net';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { startServer, type RunningServer } from '../src/server.js';
-import type {
-  DecisionLogEntry,
-  OrchestratorConfig,
-  SignalWeights,
-} from '../src/types.js';
+import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
+import type { OrchestratorConfig, SignalWeights } from '../src/types.js';
 
-// Re-declare here because src/server.ts does not re-export DecisionLogEntry
-// via a type-only barrel.
-// NOTE: Keep this in sync with the DecisionLogEntry in src/server.ts.
+// Alias for brevity.
 type LogEntry = DecisionLogEntry;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5.

Wires the hard-signal detectors (#3) and the LLM-critic (#4) into a
single decision surface, and introduces the pipeline module that runs
the orchestrator in front of `forwardChatCompletion`. Non-streamed,
2xx, `application/json` responses get an adequacy check; streams,
error responses, and non-JSON bodies pass through unchanged with an
explicit `skipped` annotation.

## Commits

Six commits. Three feat/test/docs, two fixes caught by strict-flag
typecheck in the patch-prep environment, one prettier normalization.

- **`feat(critic)`** — `OrchestratorConfig`, `OrchestratorInput`,
  `OrchestratorDecision` types. Noisy-OR aggregator over hard-signal
  confidences with per-category weights. `runOrchestrator` that
  decides `pass` / `escalate(hard_signals)` / `escalate(llm_verdict)`
  and optionally invokes the LLM-critic inside the grey band.
  `src/pipeline.ts` wraps `forwardChatCompletion` and surfaces the
  decision as `X-Turbocharger-*` headers. `src/server.ts` accepts an
  optional `orchestratorConfig` via `AppDeps`; when absent the
  server falls back to pure pass-through.
- **`test(critic,pipeline)`** — 25 orchestrator unit tests (clamp,
  noisy-OR arithmetic, grey-band gating, all decision branches) and
  6 pipeline integration tests (mock downstream, pass/escalate
  annotation, streaming skip, error skip, non-JSON skip, byte-level
  body preservation with UTF-8 content).
- **`docs`** — ADR-0013 (adequacy skipped on streams in v0.1;
  records the trade-off against tee+trailer/SSE event alternatives);
  ADR-0014 (orchestrator is a pure function, not an object);
  ADR-0015 (pipeline is a separate module from proxy, proxy stays
  narrow).
- **`fix(test)` (first)** — `stubCritic` helper's return type was
  `OrchestratorConfig['llmCritic']`, which includes `undefined`
  under `exactOptionalPropertyTypes`. Declared a concrete return
  type instead and dropped the now-unneeded non-null assertions.
- **`fix(test)` (second)** — `DecisionLogEntry` is exported from
  `src/server.ts`, not `src/types.ts`. Corrected the import path.
- **`chore`** — Prettier normalization of the three files Prettier
  chose to reformat.

## Verification

`pnpm check` green locally: 93 passed / 3 todo, no format or lint
warnings, typecheck clean, build succeeds. `dist/server.js` grew from
5.25 KB to 19.30 KB — the orchestrator and pipeline are now wired
into the server entry point, reachable whenever `orchestratorConfig`
is supplied.

## Explicitly not in this PR

- Actual escalation to a stronger model (issue #6 ladder/max). The
  orchestrator decides, the pipeline reports; no re-query happens yet.
- Body-level transparency (banner/card modes) — issue #9. The
  pipeline currently surfaces decisions only via headers and the
  structured log line.
- Zod-validated `OrchestratorConfig` loading — issue #11. The
  pipeline takes the config as a plain argument; the server accepts
  it via `AppDeps` without any file-based construction.
- Streaming adequacy checks — deferred post-MVP (ADR-0013).
- Chorus dispatch — issue #8, stub only.