### PR TITLE
docs(readme): refresh status and roadmap to reflect 5 merged issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 > Reactive model escalation sidecar for OpenClaw and any OpenAI-compatible client.
 
-**Status:** scaffold (`v0.0.1`). No functional implementation yet — this repository
-currently contains project tooling, CI, and empty module stubs only.
+**Status:** in-progress implementation. 5 of 15 MVP issues merged. The proxy,
+the adequacy detectors, the LLM-critic, the orchestrator, and the pipeline
+are in place; escalation, transparency, config-schema, and release wiring are
+still pending. No published release yet.
 
 openclaw-turbocharger fills the gap between "one cheap model for everything" and
 "one expensive model for everything." It runs whichever model you configured
@@ -14,30 +16,64 @@ It is **not** a predictive router and **not** a replacement for existing
 OpenClaw routers (ClawRouter, iblai-openclaw-router, openmark-router,
 openrouter/auto). It complements them.
 
+## What has landed
+
+The MVP is tracked as issues #2–#15 (see `PROJECT_BRIEF.md` §10). Merged so
+far, in order:
+
+1. **#2 `core`** — OpenAI-compatible HTTP server with pass-through proxy.
+   Forwards `POST /v1/chat/completions` to a configured downstream target
+   byte-for-byte, streams responses without buffering, preserves end-to-end
+   headers per RFC 7230.
+2. **#3 `critic:hard-signals`** — deterministic adequacy detectors for
+   refusal, truncation, repetition, empty/short, tool-error, and JSON
+   syntax. Each detector emits a continuous confidence in `[0, 1]` so the
+   orchestrator can aggregate without losing weak-but-present evidence.
+3. **#4 `critic:llm`** — small-model LLM critic adapter. OpenAI-compatible,
+   locale-keyed prompts (EN + DE), opt-in per-request budget check,
+   tolerant JSON extraction from the critic's response. Returns a
+   discriminated result so failure modes are never silently converted
+   into a pass.
+4. **#5 `critic:orchestrator` + pipeline** — combines hard signals (noisy-OR
+   aggregation with per-category weights) with the LLM-critic (invoked
+   only when the aggregate lands in a configurable grey band) into a
+   single decision. The pipeline wraps the proxy and surfaces the decision
+   as `X-Turbocharger-*` response headers and structured log fields.
+
+The full critic stack is now functional end-to-end — a request flows
+through the proxy, gets evaluated by the orchestrator, and its decision
+is visible to monitoring tools via response headers. What is still
+missing for a usable v0.1 is the escalation step that acts on the
+decision (re-querying with a stronger model) and the transparency layer
+that surfaces the decision to end users in the response body.
+
 ## What lands next
 
-The MVP is tracked as issues #2–#15 (see `PROJECT_BRIEF.md` §10). The next
-three, in order:
+1. **#6 `escalation:ladder`** — on `escalate` decisions, re-query with the
+   next step on a configurable model ladder (e.g. haiku → sonnet → opus).
+2. **#7 `escalation:max`** — alternative mode: single jump to a configured
+   maximum-performance model instead of stepping up the ladder.
+3. **#9 `transparency:banner`** — short user-visible banner prepended or
+   appended to the response content when escalation happened.
 
-1. **#2 `core`** — OpenAI-compatible HTTP server skeleton with pass-through proxy.
-2. **#3 `critic:hard-signals`** — deterministic adequacy detector.
-3. **#4 `critic:llm`** — small-model LLM critic adapter.
-
-Full positioning, install instructions, configuration reference, and the
-related-work section (including a respectful comparison to ClawRouter) will
-land with issues #13 and #14.
+After that: the chorus stub (#8), the card transparency mode (#10), the
+Zod-validated config schema (#11), per-request header overrides (#12),
+README and comparison document finalization (#13 + #14), and the first
+published release (#15).
 
 ## Development
 
-Requires Node ≥ 20 (pin: `.nvmrc`). pnpm preferred.
+Requires Node ≥ 22 (pin: `.nvmrc`, see `docs/DECISIONS.md` ADR-0001).
+pnpm preferred.
 
 ```bash
 pnpm install
-pnpm lint
-pnpm typecheck
-pnpm test
-pnpm build
+pnpm check
 ```
+
+`pnpm check` runs the full local pipeline: format, lint, typecheck, test,
+build (see `docs/DECISIONS.md` ADR-0009). CI on every pull request runs
+each step separately for per-step failure reporting.
 
 ## Kurzfassung (DE)
 
@@ -46,7 +82,10 @@ und Modell-Provider. Er führt die konfigurierte Default-Anfrage aus, prüft die
 Antwort anhand von Adäquanz-Signalen und eskaliert bei Bedarf auf ein stärkeres
 Modell. Eskalationen werden dem Nutzer standardmäßig transparent gemacht.
 
-Stand: Scaffold (`v0.0.1`). Funktionale Implementierung folgt ab Issue #2.
+Stand: laufende Implementierung, 5 von 15 MVP-Issues gemerged. Proxy,
+Adäquanz-Detektoren, LLM-Kritiker, Orchestrator und Pipeline sind fertig;
+Eskalation, Transparenz-Layer, Config-Schema und Release-Verdrahtung
+stehen noch aus. Es gibt noch kein veröffentlichtes Release.
 
 ## License
 


### PR DESCRIPTION
The README still described the repo as 'scaffold only, no functional implementation yet' and listed issues #2-#4 as 'what lands next', even though all three are merged and #5 (orchestrator + pipeline) is also in. New visitors saw a badly outdated picture of the project.

Rewrites:

- Status line: from 'scaffold v0.0.1' to a descriptive 'in-progress, 5 of 15 MVP issues merged' with an honest list of what's missing (escalation, transparency, config-schema, release). Drops the version number from the status since package.json is still 0.0.1 for all merged features and bumping per-issue is not part of the project's release plan; issue #15 will set the first real version.

- New 'What has landed' section: one bulleted item per merged issue (#2 proxy, #3 hard-signals, #4 llm-critic, #5 orchestrator + pipeline) with a one-sentence explanation of what each brings.

- 'What lands next' updated from #2/#3/#4 to the actual next trio: #6 ladder, #7 max, #9 banner. A short follow-on paragraph names the remaining issues (#8, #10, #11, #12, #13, #14, #15) so the roadmap is visible end-to-end.

- 'Development' section: Node >= 22 instead of >= 20 (per ADR-0001), and recommends 'pnpm check' as the canonical local workflow (per ADR-0009).

- Kurzfassung (DE) updated in parallel with the EN status line. Both language versions now say the same thing about the project state.

No code, config, or example changes — documentation only.

Going forward: the README will be updated alongside each feature issue, not left until the issue #13 polish pass, so the public face of the repo stays in sync with the code.