### PR TITLE
feat(escalation): ladder strategy (#6, ADR-0016..ADR-0018)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -717,3 +717,127 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     middleware if that simplification pays for itself.
 - **Related:** issue #5 pipeline module; issue #6 escalation will
   extend `runPipeline` to act on `escalate` decisions.
+
+## ADR-0016: Ladder is a flat list of model IDs against a single downstream
+
+- **Date:** 2026-04-21
+- **Status:** accepted
+- **Decision:** For issue #6 (`escalation:ladder`), the ladder is a
+  flat, ordered list of model IDs. Every rung is sent to the single
+  configured downstream `ProxyTarget`; per-rung `baseUrl` and
+  `apiKey` are deliberately out of scope for v0.1.
+- **Rationale:** The brief (§3 "Downstream targets") describes the
+  typical deployment as the sidecar sitting in front of *one* route
+  — a local Ollama, a hosted aggregator (OpenRouter, ClawRouter,
+  iblai-router, openmark-router), or a single provider endpoint.
+  Aggregators already expose many providers behind one base URL
+  using model-id prefixes like `anthropic/claude-sonnet-4-6` or
+  `openai/gpt-4o`, which the ladder naturally names. Making the
+  ladder a flat string list keeps the config shape trivial
+  (`ladder: [a, b, c]`), avoids a discriminated-union schema that
+  would only pay off for the minority of users who want to route
+  different rungs to different providers, and leaves a clean
+  upgrade path for a future multi-downstream variant.
+- **Alternatives considered:**
+  - _Per-rung `{model, baseUrl, apiKey}` objects._ Rejected for
+    v0.1: doubles the config schema surface, requires multi-provider
+    credential management, and the aggregators already cover the
+    intended deployments. Can be added later as a discriminated
+    union entry (string | object) without breaking existing
+    flat-list configs.
+  - _Hybrid (string or object per rung)._ Rejected for v0.1: all the
+    complexity of the per-rung variant, no simplification over the
+    flat list. If we ever add per-rung overrides, we revisit this
+    ADR and decide whether the hybrid or a separate
+    `perRungOverrides` map is the cleaner shape.
+- **Related:** issue #6. Post-MVP candidate: a per-rung override
+  feature if and when real deployments ask for it. Issue #12
+  (per-request header overrides) covers the orthogonal "force a
+  specific model for this call" case.
+
+## ADR-0017: The discarded original response is not surfaced to the client
+
+- **Date:** 2026-04-21
+- **Status:** accepted
+- **Decision:** When the pipeline escalates, the original response
+  bodies from rungs below the final one are not retained and not
+  surfaced to the client in any form — not in headers, not in the
+  response body, not as an additional field. Only the final
+  attempted response's body reaches the client. Headers record the
+  escalation path (which rungs were tried) and the stopping reason,
+  but not the discarded content.
+- **Rationale:** The escalation exists because the original answer
+  was judged inadequate. Passing it through alongside the final
+  answer forces the client to re-implement adequacy judgement just
+  to decide which version to show, which defeats the point of the
+  critic pipeline. The transparency layer (issues #9 and #10) is
+  the correct place to surface escalation metadata in the body —
+  the banner (#9) names the escalation as a short line, and the
+  card (#10) can include a structured record of the path. Keeping
+  those concerns separated keeps issue #6 focused on the re-query
+  mechanics. The brief's §6 "no weak answer forwarded to stronger
+  model" directive is honoured at a different layer (we do not
+  prime the stronger model with the weaker model's output), but the
+  same spirit — not letting the weak answer continue to influence
+  the interaction — also argues for not putting it in front of the
+  client.
+- **Alternatives considered:**
+  - _Include the original response(s) as `X-Turbocharger-Original-*`
+    headers._ Rejected: header size limits make this fragile for
+    anything but trivial responses, and most log aggregators will
+    redact or truncate non-standard header payloads.
+  - _Append the originals as extra JSON fields alongside
+    `choices`._ Rejected for v0.1: modifies the response body,
+    which the issue #5 pipeline established as off-limits outside
+    the explicit transparency modes of issues #9/#10.
+  - _Expose the originals via a separate API endpoint (`GET
+    /v1/traces/{id}`)._ Rejected for v0.1: would require request-id
+    generation and an audit-log backing store. Tracked in the
+    post-MVP backlog; see ADR-0007 on the audit-log tier.
+- **Related:** issue #6 (this ADR); issues #9 and #10 for the body-
+  level transparency surfaces where the discarded content may
+  resurface by design.
+
+## ADR-0018: Default max escalation depth is 2
+
+- **Date:** 2026-04-21
+- **Status:** accepted
+- **Decision:** The recommended default for `EscalationConfig.maxDepth`
+  is 2: the pipeline performs at most two re-queries after the
+  initial attempt, so the client sees an answer from at most the
+  third ladder step. `maxDepth: 0` disables escalation entirely
+  (decisions are still reported but no re-query runs); `maxDepth: 1`
+  allows one escalation. The type surface does not embed this
+  default — callers must supply the value explicitly — but the
+  brief (§5 "Max escalation depth: configurable, default 2") and
+  examples use 2.
+- **Rationale:** Two escalations covers the realistic useful range:
+  the weakest → mid model upgrade fixes most refusal and truncation
+  cases; the mid → strong upgrade catches genuinely hard prompts
+  that the mid model also fails. A third or fourth upgrade rarely
+  changes the outcome — if even the strong model cannot answer, the
+  bottleneck is usually the prompt (unanswerable, malformed,
+  out-of-policy) rather than the model. Capping at 2 bounds
+  worst-case latency and cost: the client-facing latency is at most
+  three downstream round-trips plus two critic passes, and the cost
+  budget is the sum of three completions plus two critic calls —
+  enough to reason about in a headroom calculation, unlike a
+  depth-5 or unlimited variant.
+- **Alternatives considered:**
+  - _Default = ladder length (walk the whole ladder until pass or
+    exhaustion)._ Rejected: the upper bound on worst-case cost
+    becomes the ladder length, which in the brief's example is 4.
+    Users who configure longer ladders for exploratory reasons
+    would pay for that exploration on every escalation.
+  - _Default 1 (one escalation only, then stop)._ Rejected:
+    insufficient for the realistic mid → strong-upgrade case.
+    Users would hit the depth ceiling on exactly the prompts they
+    care most about.
+  - _Default unbounded, cap via USD budget only._ Rejected:
+    coupling escalation depth to cost accounting makes each
+    re-query's decision path harder to reason about. A depth cap
+    is orthogonal to a cost cap; having both is fine, having one
+    replace the other is not.
+- **Related:** issue #6 (this ADR); issue #11 will introduce the
+  Zod schema that materializes the default in the validated config
+  loader.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -727,7 +727,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   configured downstream `ProxyTarget`; per-rung `baseUrl` and
   `apiKey` are deliberately out of scope for v0.1.
 - **Rationale:** The brief (§3 "Downstream targets") describes the
-  typical deployment as the sidecar sitting in front of *one* route
+  typical deployment as the sidecar sitting in front of _one_ route
   — a local Ollama, a hosted aggregator (OpenRouter, ClawRouter,
   iblai-router, openmark-router), or a single provider endpoint.
   Aggregators already expose many providers behind one base URL
@@ -791,7 +791,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     which the issue #5 pipeline established as off-limits outside
     the explicit transparency modes of issues #9/#10.
   - _Expose the originals via a separate API endpoint (`GET
-    /v1/traces/{id}`)._ Rejected for v0.1: would require request-id
+/v1/traces/{id}`)._ Rejected for v0.1: would require request-id
     generation and an audit-log backing store. Tracked in the
     post-MVP backlog; see ADR-0007 on the audit-log tier.
 - **Related:** issue #6 (this ADR); issues #9 and #10 for the body-

--- a/src/escalation/index.ts
+++ b/src/escalation/index.ts
@@ -1,5 +1,10 @@
-// TODO(issue #6): Strategy dispatch — ladder | max | chorus.
-// Reads per-request override from X-Turbocharger-Mode header (issue #12).
-// Enforces max_escalation_depth (default 2) to prevent runaway costs.
+// Escalation module barrel.
+//
+// Issue #6 exposes the ladder strategy as a pure function. Issues #7
+// (max) and #8 (chorus-stub) will add their own strategy modules here.
+// The pipeline (src/pipeline.ts) selects the active strategy from the
+// configured {@link EscalationConfig.mode} and calls the strategy's
+// pure helpers to compute the next model. The pipeline itself owns the
+// re-query loop so the strategy modules stay stateless and testable.
 
-export {};
+export { nextLadderStep, remainingLadderSteps } from './ladder.js';

--- a/src/escalation/ladder.ts
+++ b/src/escalation/ladder.ts
@@ -32,10 +32,7 @@
  * `Anthropic/Claude-Haiku-4-5` are not the same model) and we do not
  * silently normalize.
  */
-export function nextLadderStep(
-  currentModel: string,
-  ladder: readonly string[],
-): string | null {
+export function nextLadderStep(currentModel: string, ladder: readonly string[]): string | null {
   if (ladder.length === 0) return null;
   const index = ladder.indexOf(currentModel);
   if (index === -1) return null;
@@ -50,10 +47,7 @@ export function nextLadderStep(
  * the configured `maxDepth` still allows it but the ladder has nothing
  * more to offer.
  */
-export function remainingLadderSteps(
-  currentModel: string,
-  ladder: readonly string[],
-): number {
+export function remainingLadderSteps(currentModel: string, ladder: readonly string[]): number {
   if (ladder.length === 0) return 0;
   const index = ladder.indexOf(currentModel);
   if (index === -1) return 0;

--- a/src/escalation/ladder.ts
+++ b/src/escalation/ladder.ts
@@ -1,6 +1,61 @@
-// TODO(issue #6): Ladder strategy.
-// Escalate one step up on a user-defined chain
-// (e.g. haiku → sonnet → opus). Can escalate multiple steps on repeated failure,
-// bounded by max_escalation_depth.
+// Ladder escalation strategy: step up a user-configured chain of model IDs
+// one rung at a time when the orchestrator (issue #5) signals that the
+// current model's answer is inadequate.
+//
+// Scope (v0.1, issue #6):
+//   - Pure function {@link nextLadderStep} that resolves the position of a
+//     current model on a ladder and returns the next rung, or `null` when
+//     the ladder is exhausted or the current model is unknown.
+//   - No I/O, no state, no escalation execution — those live in the
+//     pipeline (src/pipeline.ts) which loops nextLadderStep + forward +
+//     orchestrate until a pass, ladder exhaustion, or the configured
+//     maxDepth is reached.
+//
+// Intentionally NOT in this file:
+//   - The escalation loop itself — pipeline.ts owns the re-query logic so
+//     the strategy modules stay pure and independently testable.
+//   - Per-model baseUrl / apiKey — see ADR-0016. v0.1 sends every ladder
+//     step to the single configured downstream ProxyTarget.
+//   - Max-mode and chorus dispatch — issues #7 and #8 respectively.
 
-export {};
+/**
+ * Find the next model on the ladder above `currentModel`. Returns
+ * `null` when:
+ * - the current model is not on the ladder (caller decides whether to
+ *   treat that as "start from the bottom" or "don't escalate"; the
+ *   pipeline treats it as the latter per ADR-0016);
+ * - the current model is already the top rung;
+ * - the ladder is empty.
+ *
+ * Case-sensitive match on the model ID — provider IDs are
+ * conventionally case-sensitive (`anthropic/claude-haiku-4-5` vs
+ * `Anthropic/Claude-Haiku-4-5` are not the same model) and we do not
+ * silently normalize.
+ */
+export function nextLadderStep(
+  currentModel: string,
+  ladder: readonly string[],
+): string | null {
+  if (ladder.length === 0) return null;
+  const index = ladder.indexOf(currentModel);
+  if (index === -1) return null;
+  if (index >= ladder.length - 1) return null;
+  return ladder[index + 1] ?? null;
+}
+
+/**
+ * Count how many ladder steps remain above `currentModel`. Returns `0`
+ * when the current model is at the top of or not on the ladder. Used
+ * by the pipeline to decide whether to attempt escalation at all when
+ * the configured `maxDepth` still allows it but the ladder has nothing
+ * more to offer.
+ */
+export function remainingLadderSteps(
+  currentModel: string,
+  ladder: readonly string[],
+): number {
+  if (ladder.length === 0) return 0;
+  const index = ladder.indexOf(currentModel);
+  if (index === -1) return 0;
+  return Math.max(0, ladder.length - 1 - index);
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -319,7 +319,19 @@ export async function runPipeline(
 
   const path: string[] = [];
   let depth = 0;
-  let stoppedReason: EscalationTrace['stoppedReason'] = 'passed';
+  // Default stoppedReason is 'not_attempted', which is correct for
+  // every case where the escalation loop does not run at all: no
+  // escalation config, non-ladder mode, maxDepth === 0, or the very
+  // first orchestrator decision was escalate but the loop condition
+  // still prevents re-query. The up-front 'pass' check below promotes
+  // it to 'passed' when the first response was already adequate; every
+  // branch inside the loop that stops early explicitly sets its own
+  // final value.
+  let stoppedReason: EscalationTrace['stoppedReason'] = 'not_attempted';
+
+  if (currentDecision.kind === 'pass') {
+    stoppedReason = 'passed';
+  }
 
   // Escalation loop. Runs only when:
   //   - the orchestrator decided `escalate`,
@@ -388,16 +400,6 @@ export async function runPipeline(
       stoppedReason = 'max_depth_reached';
       break;
     }
-  }
-
-  // If no escalation happened at all, the stoppedReason is either
-  // 'passed' (first response was adequate) or 'not_attempted' (no
-  // escalation config, or decision wasn't escalate, or mode isn't
-  // ladder).
-  if (path.length === 0 && currentDecision.kind === 'pass') {
-    stoppedReason = 'passed';
-  } else if (path.length === 0 && currentDecision.kind === 'escalate') {
-    stoppedReason = 'not_attempted';
   }
 
   const trace: EscalationTrace = { path, stoppedReason, depth };

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -67,9 +67,7 @@ async function parseClientRequest(request: Request): Promise<ParsedRequest> {
   const model = readString(parsed, 'model') ?? '';
   const locale = readString(parsed, 'locale') ?? readHeaderLocale(request);
   const body =
-    parsed !== null && typeof parsed === 'object'
-      ? (parsed as Record<string, unknown>)
-      : null;
+    parsed !== null && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
 
   return {
     stream,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,32 +1,45 @@
-// Pipeline: forwards a chat/completions request via the proxy, then runs
-// the orchestrator against the response body to produce an
-// {@link OrchestratorDecision}. Returns the (possibly annotated)
-// response and the decision; the caller (server.ts) emits headers and
-// the log line.
+// Pipeline: forwards a chat/completions request via the proxy, runs the
+// orchestrator against the response body to produce an
+// {@link OrchestratorDecision}, and — when an escalation strategy is
+// configured (issue #6) — re-queries with the next model on the ladder
+// until either the response passes, the ladder is exhausted, or the
+// configured `maxDepth` is reached. Returns the (possibly annotated)
+// final response plus a trace of what happened; the caller (server.ts)
+// emits headers and the log line.
 //
-// Scope (v0.1, issue #5):
+// Scope (v0.1, issue #6):
 //   - Non-streamed `application/json` responses with 2xx status are
 //     evaluated. The body is buffered, the orchestrator runs against
-//     the assembled content, and the decision is surfaced via
-//     X-Turbocharger-* headers on the response that is returned to the
-//     client. Body bytes are unchanged.
+//     the assembled content, and — on an `escalate` decision — the
+//     pipeline re-sends the same request body with the next ladder
+//     model's id substituted into `model:`. Successive responses are
+//     re-evaluated by the orchestrator until a stopping condition is
+//     met (see EscalationTrace.stoppedReason).
 //   - Streamed responses (`stream: true` or `text/event-stream`) are
-//     skipped per ADR-0013. The orchestrator returns
-//     { kind: 'skipped', reason: 'streaming' }; the response is
-//     forwarded unchanged and no decision headers are added.
-//   - Non-2xx responses are skipped (the downstream already signalled
-//     failure; the critic has no role), as are non-JSON bodies.
+//     skipped per ADR-0013. No orchestrator, no escalation.
+//   - Non-2xx responses and non-JSON bodies short-circuit the
+//     orchestrator and escalation alike.
 //
 // Intentionally NOT in this file:
-//   - The actual escalation machinery. Issue #5 only decides; issue #6
-//     (ladder/max) acts on the decision.
-//   - Config loading. The pipeline takes an OrchestratorConfig as
-//     input; how that config is built (env, YAML, Zod schema) is
-//     issue #11.
+//   - Body-level transparency (banner / card in response content) —
+//     issue #9. This file surfaces decisions via headers only.
+//   - The discarded original responses are not retained or surfaced to
+//     the client, per ADR-0017. Only the final attempted response
+//     reaches the client body.
+//   - Max-mode and chorus-mode escalation — the dispatch here treats
+//     `mode !== 'ladder'` as "no escalation" so that issues #7 and #8
+//     can plug in without reshaping this file.
 
-import { forwardChatCompletion } from './proxy.js';
 import { runOrchestrator } from './critic/orchestrator.js';
-import type { OrchestratorConfig, OrchestratorDecision, ProxyTarget } from './types.js';
+import { nextLadderStep } from './escalation/ladder.js';
+import { forwardChatCompletion } from './proxy.js';
+import type {
+  EscalationConfig,
+  EscalationTrace,
+  OrchestratorConfig,
+  OrchestratorDecision,
+  ProxyTarget,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Request inspection
@@ -35,34 +48,34 @@ import type { OrchestratorConfig, OrchestratorDecision, ProxyTarget } from './ty
 interface ParsedRequest {
   readonly stream: boolean;
   readonly userPrompt: string;
+  readonly model: string;
   readonly locale?: string;
+  /** Parsed JSON body, or `null` if parsing failed. */
+  readonly body: Record<string, unknown> | null;
 }
 
-/**
- * Inspect the client's chat/completions request body to decide whether
- * streaming was requested, extract the last user message for the
- * orchestrator, and pick up an optional locale hint.
- *
- * The original Request is not consumed: the caller owns the original,
- * we clone for inspection so that {@link forwardChatCompletion} can
- * still read the body bytes.
- */
 async function parseClientRequest(request: Request): Promise<ParsedRequest> {
   let parsed: unknown = null;
   try {
     parsed = await request.clone().json();
   } catch {
-    // Not JSON, or malformed. Proceed with safe defaults; the downstream
-    // will return an HTTP error and the orchestrator will skip it.
+    // Not JSON, or malformed. Downstream will error; orchestrator will skip.
   }
 
   const stream = readBoolean(parsed, 'stream');
   const userPrompt = extractUserPrompt(parsed);
+  const model = readString(parsed, 'model') ?? '';
   const locale = readString(parsed, 'locale') ?? readHeaderLocale(request);
+  const body =
+    parsed !== null && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : null;
 
   return {
     stream,
     userPrompt,
+    model,
+    body,
     ...(locale !== undefined ? { locale } : {}),
   };
 }
@@ -82,7 +95,6 @@ function readString(obj: unknown, key: string): string | undefined {
 function readHeaderLocale(request: Request): string | undefined {
   const hdr = request.headers.get('accept-language');
   if (hdr === null || hdr.length === 0) return undefined;
-  // Simplest possible parse: take the first tag, strip any q-factor.
   const first = hdr.split(',')[0];
   if (first === undefined) return undefined;
   const tag = first.split(';')[0]?.trim();
@@ -93,7 +105,6 @@ function extractUserPrompt(parsed: unknown): string {
   if (typeof parsed !== 'object' || parsed === null) return '';
   const messages = (parsed as Record<string, unknown>)['messages'];
   if (!Array.isArray(messages)) return '';
-  // Walk from the end, find the last message with role === 'user'.
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (typeof msg !== 'object' || msg === null) continue;
@@ -101,7 +112,6 @@ function extractUserPrompt(parsed: unknown): string {
     if (role !== 'user') continue;
     const content = (msg as Record<string, unknown>)['content'];
     if (typeof content === 'string') return content;
-    // OpenAI supports array-of-parts content; extract text parts only.
     if (Array.isArray(content)) {
       const parts: string[] = [];
       for (const part of content) {
@@ -126,10 +136,6 @@ interface ParsedResponse {
   readonly finishReason?: string;
 }
 
-/** Extract the assistant content and finish_reason from a non-streamed
- * chat/completions JSON body. Returns empty strings for anything
- * unexpected — the orchestrator's empty/short detector catches those
- * naturally. */
 function parseChatCompletionBody(json: unknown): ParsedResponse {
   if (typeof json !== 'object' || json === null) return { content: '' };
   const choices = (json as Record<string, unknown>)['choices'];
@@ -150,14 +156,41 @@ function parseChatCompletionBody(json: unknown): ParsedResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Escalation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Request object for a single escalation attempt: clone the
+ * original request body, substitute the `model` field, and send it to
+ * the same downstream. The resulting Request is passed to
+ * {@link forwardChatCompletion} exactly like the original would be.
+ *
+ * All headers are preserved from the original Request so that
+ * Authorization, Content-Type, and any client-supplied `X-*` headers
+ * stay consistent across escalation steps.
+ */
+function buildEscalationRequest(
+  original: Request,
+  body: Record<string, unknown>,
+  newModel: string,
+): Request {
+  const newBody = { ...body, model: newModel };
+  return new Request(original.url, {
+    method: original.method,
+    headers: original.headers,
+    body: JSON.stringify(newBody),
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Header annotation
 // ---------------------------------------------------------------------------
 
-/** Attach X-Turbocharger-* headers describing the decision. Header
- * values never contain newlines or control characters. The reason
- * strings from individual signals are condensed to a comma-separated
- * category list to keep header sizes modest. */
-function annotateResponse(response: Response, decision: OrchestratorDecision): Response {
+function annotateResponse(
+  response: Response,
+  decision: OrchestratorDecision,
+  trace: EscalationTrace,
+): Response {
   const headers = new Headers(response.headers);
 
   switch (decision.kind) {
@@ -193,6 +226,15 @@ function annotateResponse(response: Response, decision: OrchestratorDecision): R
     }
   }
 
+  // Escalation trace is always emitted when a trace exists (even
+  // "not_attempted" for pass-first-try responses — makes client-side
+  // log parsing uniform).
+  headers.set('x-turbocharger-escalation-depth', String(trace.depth));
+  headers.set('x-turbocharger-escalation-stopped', trace.stoppedReason);
+  if (trace.path.length > 0) {
+    headers.set('x-turbocharger-escalation-path', trace.path.join(','));
+  }
+
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -207,91 +249,189 @@ function annotateResponse(response: Response, decision: OrchestratorDecision): R
 export interface PipelineResult {
   readonly response: Response;
   readonly decision: OrchestratorDecision;
+  readonly trace: EscalationTrace;
 }
 
 /**
- * Run the full pipeline: forward the request, then run the orchestrator
- * against the response if it is evaluable (non-streamed JSON, 2xx).
- * Returns the (possibly annotated) response and the decision.
- *
- * Streams and error responses skip the orchestrator by design:
- * - Streaming responses (ADR-0013) are not inspected in v0.1.
- * - Non-2xx responses are passed through with no critic involvement.
+ * Run the full pipeline: forward the request, run the orchestrator on
+ * the response, and — when configured — escalate up a ladder of models
+ * until the response passes or a stopping condition is reached.
  */
 export async function runPipeline(
   request: Request,
   target: ProxyTarget,
   orchestratorConfig: OrchestratorConfig,
+  escalationConfig?: EscalationConfig,
 ): Promise<PipelineResult> {
   const parsed = await parseClientRequest(request);
-  const downstream = await forwardChatCompletion(request, target);
 
-  // Short-circuit paths that bypass the orchestrator entirely. The
-  // response body is already a ReadableStream in these cases; we must
-  // not consume it, or the client will see an empty body.
+  // Short-circuit paths that bypass the orchestrator entirely.
   if (parsed.stream) {
     const decision: OrchestratorDecision = { kind: 'skipped', reason: 'streaming' };
-    return { response: annotateResponse(downstream, decision), decision };
+    const trace: EscalationTrace = {
+      path: [],
+      stoppedReason: 'not_attempted',
+      depth: 0,
+    };
+    const downstream = await forwardChatCompletion(request, target);
+    return { response: annotateResponse(downstream, decision, trace), decision, trace };
   }
-  if (!downstream.ok) {
+
+  // First attempt: forward the original request.
+  const firstResponse = await forwardChatCompletion(request, target);
+
+  if (!firstResponse.ok) {
     const decision: OrchestratorDecision = {
       kind: 'skipped',
       reason: 'non_ok_status',
-      detail: `${downstream.status} ${downstream.statusText}`,
+      detail: `${firstResponse.status} ${firstResponse.statusText}`,
     };
-    return { response: annotateResponse(downstream, decision), decision };
+    const trace: EscalationTrace = {
+      path: [],
+      stoppedReason: 'not_attempted',
+      depth: 0,
+    };
+    return { response: annotateResponse(firstResponse, decision, trace), decision, trace };
   }
 
-  const contentType = downstream.headers.get('content-type') ?? '';
+  const contentType = firstResponse.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/json')) {
     const decision: OrchestratorDecision = {
       kind: 'skipped',
       reason: 'non_json_content_type',
       detail: contentType,
     };
-    return { response: annotateResponse(downstream, decision), decision };
-  }
-
-  // Buffer the response body. Chat-completion JSON payloads are small;
-  // the streaming case above handles the one that could be large.
-  const bodyText = await downstream.text();
-
-  let bodyJson: unknown;
-  try {
-    bodyJson = JSON.parse(bodyText);
-  } catch {
-    // Downstream claimed JSON but produced something we can't parse.
-    // Forward the body bytes unchanged and skip the orchestrator.
-    const decision: OrchestratorDecision = {
-      kind: 'skipped',
-      reason: 'non_json_content_type',
-      detail: 'JSON parse failure',
+    const trace: EscalationTrace = {
+      path: [],
+      stoppedReason: 'not_attempted',
+      depth: 0,
     };
-    const reconstituted = new Response(bodyText, {
-      status: downstream.status,
-      statusText: downstream.statusText,
-      headers: downstream.headers,
-    });
-    return { response: annotateResponse(reconstituted, decision), decision };
+    return { response: annotateResponse(firstResponse, decision, trace), decision, trace };
   }
 
-  const assistant = parseChatCompletionBody(bodyJson);
-  const decision = await runOrchestrator(
-    {
-      response: assistant.content,
-      userPrompt: parsed.userPrompt,
-      ...(assistant.finishReason !== undefined ? { finishReason: assistant.finishReason } : {}),
-      ...(parsed.locale !== undefined ? { locale: parsed.locale } : {}),
-    },
+  // First response is a JSON body we can evaluate.
+  let currentResponse = firstResponse;
+  let currentBodyText = await currentResponse.text();
+  let currentModel = parsed.model;
+  let currentAssistant = parseChatCompletionBody(safeJsonParse(currentBodyText));
+  let currentDecision: OrchestratorDecision = await runOrchestrator(
+    buildOrchestratorInput(currentAssistant, parsed),
     orchestratorConfig,
   );
 
-  // Rebuild the response with the original body text (so the client
-  // gets the exact bytes the downstream sent).
-  const reconstituted = new Response(bodyText, {
-    status: downstream.status,
-    statusText: downstream.statusText,
-    headers: downstream.headers,
+  const path: string[] = [];
+  let depth = 0;
+  let stoppedReason: EscalationTrace['stoppedReason'] = 'passed';
+
+  // Escalation loop. Runs only when:
+  //   - the orchestrator decided `escalate`,
+  //   - an escalation config is provided,
+  //   - the mode is `ladder` (other modes fall through untouched; issues #7/#8),
+  //   - `maxDepth` has not yet been spent,
+  //   - a next ladder step exists.
+  while (
+    currentDecision.kind === 'escalate' &&
+    escalationConfig !== undefined &&
+    escalationConfig.mode === 'ladder' &&
+    depth < escalationConfig.maxDepth
+  ) {
+    const next = nextLadderStep(currentModel, escalationConfig.ladder);
+    if (next === null) {
+      // Current model isn't on the ladder, or we're at the top. Stop
+      // with an informative reason so monitors can distinguish the two
+      // off-ladder cases from actual ladder exhaustion.
+      stoppedReason =
+        escalationConfig.ladder.indexOf(currentModel) === -1
+          ? 'model_not_on_ladder'
+          : 'ladder_exhausted';
+      break;
+    }
+
+    path.push(next);
+    depth += 1;
+
+    const reQueryRequest = buildEscalationRequest(request, parsed.body ?? {}, next);
+    const reQueryResponse = await forwardChatCompletion(reQueryRequest, target);
+
+    if (!reQueryResponse.ok) {
+      // The re-query itself failed at the HTTP level. Stop the loop and
+      // hand the last failing response back so the client can see what
+      // happened. The decision stays `escalate`.
+      currentResponse = reQueryResponse;
+      currentBodyText = await reQueryResponse.text();
+      stoppedReason = 'max_depth_reached';
+      break;
+    }
+
+    const reQueryContentType = reQueryResponse.headers.get('content-type') ?? '';
+    if (!reQueryContentType.toLowerCase().includes('application/json')) {
+      // Similar handling: if the re-query returns non-JSON, stop and
+      // return that body unchanged.
+      currentResponse = reQueryResponse;
+      currentBodyText = await reQueryResponse.text();
+      stoppedReason = 'max_depth_reached';
+      break;
+    }
+
+    currentResponse = reQueryResponse;
+    currentBodyText = await reQueryResponse.text();
+    currentAssistant = parseChatCompletionBody(safeJsonParse(currentBodyText));
+    currentModel = next;
+    currentDecision = await runOrchestrator(
+      buildOrchestratorInput(currentAssistant, parsed),
+      orchestratorConfig,
+    );
+
+    if (currentDecision.kind === 'pass') {
+      stoppedReason = 'passed';
+      break;
+    }
+    if (depth >= escalationConfig.maxDepth) {
+      stoppedReason = 'max_depth_reached';
+      break;
+    }
+  }
+
+  // If no escalation happened at all, the stoppedReason is either
+  // 'passed' (first response was adequate) or 'not_attempted' (no
+  // escalation config, or decision wasn't escalate, or mode isn't
+  // ladder).
+  if (path.length === 0 && currentDecision.kind === 'pass') {
+    stoppedReason = 'passed';
+  } else if (path.length === 0 && currentDecision.kind === 'escalate') {
+    stoppedReason = 'not_attempted';
+  }
+
+  const trace: EscalationTrace = { path, stoppedReason, depth };
+
+  const reconstituted = new Response(currentBodyText, {
+    status: currentResponse.status,
+    statusText: currentResponse.statusText,
+    headers: currentResponse.headers,
   });
-  return { response: annotateResponse(reconstituted, decision), decision };
+  return {
+    response: annotateResponse(reconstituted, currentDecision, trace),
+    decision: currentDecision,
+    trace,
+  };
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function buildOrchestratorInput(
+  assistant: ParsedResponse,
+  parsed: ParsedRequest,
+): Parameters<typeof runOrchestrator>[0] {
+  return {
+    response: assistant.content,
+    userPrompt: parsed.userPrompt,
+    ...(assistant.finishReason !== undefined ? { finishReason: assistant.finishReason } : {}),
+    ...(parsed.locale !== undefined ? { locale: parsed.locale } : {}),
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -155,9 +155,7 @@ export function startServer(
     ...(deps?.orchestratorConfig !== undefined
       ? { orchestratorConfig: deps.orchestratorConfig }
       : {}),
-    ...(deps?.escalationConfig !== undefined
-      ? { escalationConfig: deps.escalationConfig }
-      : {}),
+    ...(deps?.escalationConfig !== undefined ? { escalationConfig: deps.escalationConfig } : {}),
   });
 
   const server = serve({

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,12 @@
 // OpenAI-compatible HTTP server entry.
 //
-// Issue #2 introduced the pass-through proxy. Issue #5 adds an optional
-// orchestrator pipeline in front of the proxy: when `pipelineConfig` is
-// present in {@link AppDeps}, the request flows through
-// {@link runPipeline} instead of directly through
-// {@link forwardChatCompletion}, and the resulting decision is surfaced
-// in response headers and in the per-request log line.
+// Issue #2 introduced the pass-through proxy. Issue #5 added the optional
+// orchestrator pipeline. Issue #6 extends the same pipeline with a
+// ladder-escalation strategy: when the orchestrator decides `escalate`,
+// the pipeline loops through the configured ladder of models until the
+// response passes, the ladder is exhausted, or the configured maxDepth
+// is reached. All three are opt-in via AppDeps; the server falls back
+// to pass-through forwarding when orchestratorConfig is absent.
 
 import { fileURLToPath } from 'node:url';
 
@@ -17,6 +18,8 @@ import { runPipeline } from './pipeline.js';
 import { forwardChatCompletion } from './proxy.js';
 import type {
   AppConfig,
+  EscalationConfig,
+  EscalationTrace,
   OrchestratorConfig,
   OrchestratorDecision,
   ProxyTarget,
@@ -29,22 +32,31 @@ export interface AppDeps {
   /** Optional logger override; defaults to one JSON object per line on stderr. */
   readonly logger?: RequestLogger;
   /**
-   * Optional orchestrator configuration. When present, the server runs
-   * the full {@link runPipeline} (proxy + orchestrator) and adds
-   * X-Turbocharger-* response headers and a decision field to the log
-   * line. When absent, the server falls back to the pass-through proxy
-   * behaviour from issue #2.
+   * Optional orchestrator configuration. When present, requests flow
+   * through {@link runPipeline}; otherwise the server is a pure
+   * pass-through proxy (issue #2 behaviour).
    */
   readonly orchestratorConfig?: OrchestratorConfig;
+  /**
+   * Optional escalation configuration. Only consulted when
+   * `orchestratorConfig` is also present. When absent, the pipeline runs
+   * the orchestrator but never re-queries — decisions are reported via
+   * headers and logs only (issue #5 behaviour).
+   */
+  readonly escalationConfig?: EscalationConfig;
 }
 
 /**
- * Per-request log entry with an optional orchestrator decision field.
- * Extends {@link RequestLogEntry} without modifying its narrow shape.
+ * Per-request log entry with optional orchestrator and escalation fields.
+ * Extends {@link RequestLogEntry} without changing its base shape so that
+ * non-pipeline requests keep emitting the narrower object.
  */
 export interface DecisionLogEntry extends RequestLogEntry {
   readonly decision?: OrchestratorDecision['kind'];
   readonly decision_reason?: string;
+  readonly escalation_depth?: number;
+  readonly escalation_stopped?: EscalationTrace['stoppedReason'];
+  readonly escalation_path?: readonly string[];
 }
 
 const defaultLogger: RequestLogger = (entry) => {
@@ -65,13 +77,26 @@ export function createApp(deps: AppDeps): Hono {
     let status = 0;
     let decisionKind: OrchestratorDecision['kind'] | undefined;
     let decisionReason: string | undefined;
+    let escalationDepth: number | undefined;
+    let escalationStopped: EscalationTrace['stoppedReason'] | undefined;
+    let escalationPath: readonly string[] | undefined;
     try {
       if (deps.orchestratorConfig !== undefined) {
-        const result = await runPipeline(c.req.raw, deps.proxyTarget, deps.orchestratorConfig);
+        const result = await runPipeline(
+          c.req.raw,
+          deps.proxyTarget,
+          deps.orchestratorConfig,
+          deps.escalationConfig,
+        );
         status = result.response.status;
         decisionKind = result.decision.kind;
         if (result.decision.kind === 'escalate' || result.decision.kind === 'skipped') {
           decisionReason = result.decision.reason;
+        }
+        escalationDepth = result.trace.depth;
+        escalationStopped = result.trace.stoppedReason;
+        if (result.trace.path.length > 0) {
+          escalationPath = result.trace.path;
         }
         return result.response;
       }
@@ -79,12 +104,6 @@ export function createApp(deps: AppDeps): Hono {
       status = downstream.status;
       return downstream;
     } catch (err) {
-      // The fetch call itself failed (downstream unreachable, DNS failure,
-      // connection reset before any HTTP response). Surface as 502 with a
-      // diagnostic body. HTTP-level errors from a reachable downstream go
-      // through the success branch above and are forwarded verbatim — the
-      // sidecar never invents its own error status when the downstream
-      // produced one.
       status = 502;
       const message = err instanceof Error ? err.message : 'unknown error';
       return c.json(
@@ -105,6 +124,9 @@ export function createApp(deps: AppDeps): Hono {
         latency_ms: Date.now() - start,
         ...(decisionKind !== undefined ? { decision: decisionKind } : {}),
         ...(decisionReason !== undefined ? { decision_reason: decisionReason } : {}),
+        ...(escalationDepth !== undefined ? { escalation_depth: escalationDepth } : {}),
+        ...(escalationStopped !== undefined ? { escalation_stopped: escalationStopped } : {}),
+        ...(escalationPath !== undefined ? { escalation_path: escalationPath } : {}),
       };
       log(entry);
     }
@@ -115,15 +137,10 @@ export function createApp(deps: AppDeps): Hono {
 
 /** Handle returned by {@link startServer} for graceful shutdown. */
 export interface RunningServer {
-  /** The address the server is listening on, for tests that bind port 0. */
   readonly port: number;
   close(): Promise<void>;
 }
 
-/**
- * Start the sidecar HTTP server on the configured port. Returns a handle
- * with a `close()` for graceful shutdown.
- */
 export function startServer(
   config: AppConfig = loadEnvConfig(),
   deps?: Omit<AppDeps, 'proxyTarget'>,
@@ -137,6 +154,9 @@ export function startServer(
     ...(deps?.logger !== undefined ? { logger: deps.logger } : {}),
     ...(deps?.orchestratorConfig !== undefined
       ? { orchestratorConfig: deps.orchestratorConfig }
+      : {}),
+    ...(deps?.escalationConfig !== undefined
+      ? { escalationConfig: deps.escalationConfig }
       : {}),
   });
 
@@ -157,9 +177,6 @@ export function startServer(
   };
 }
 
-// Self-execution guard: running `node dist/server.js` boots the server;
-// importing the module from another file does not. Standard Node ESM
-// idiom for "is this the entry point".
 const isDirectRun = (() => {
   if (process.argv[1] === undefined) return false;
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,8 @@
 // consistent. Issue #2 introduces the minimal surface needed for the
 // pass-through proxy; issue #3 adds the hard-signal detection surface;
 // issue #4 adds the LLM-critic surface; issue #5 adds the orchestrator and
-// pipeline surfaces; later issues extend further.
+// pipeline surfaces; issue #6 adds the escalation surface; later issues
+// extend further.
 
 /**
  * Effective configuration for a running sidecar process.
@@ -311,3 +312,82 @@ export type Orchestrator = (
   input: OrchestratorInput,
   config: OrchestratorConfig,
 ) => Promise<OrchestratorDecision>;
+
+// ---------------------------------------------------------------------------
+// Escalation (issue #6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mode of escalation selected when an {@link OrchestratorDecision} is
+ * `kind: 'escalate'`.
+ *
+ * - `ladder`: step up a user-configured chain of model IDs one rung at a
+ *   time. Issue #6.
+ * - `max`: jump directly to a single configured maximum-performance
+ *   model. Issue #7 (stub in #6).
+ * - `chorus`: dispatch to an external chorus endpoint for multi-model
+ *   consensus. Issue #8 (interface only; no implementation in v0.1).
+ */
+export type EscalationMode = 'ladder' | 'max' | 'chorus';
+
+/**
+ * Configuration for the escalation strategy. Per ADR-0016, the ladder is
+ * a flat list of model IDs addressed against the single configured
+ * downstream {@link ProxyTarget}; per-model baseUrls are deliberately
+ * out of scope for v0.1.
+ *
+ * Per ADR-0018 the default for `maxDepth` is 2 (one initial attempt plus
+ * up to two escalations, i.e. the client sees an answer from at most the
+ * third ladder step). Callers must supply it explicitly; there are no
+ * silent defaults at this layer.
+ */
+export interface EscalationConfig {
+  readonly mode: EscalationMode;
+  /**
+   * Ordered list of model IDs from weakest to strongest. The ladder's
+   * semantics: the client-supplied `model` field in the request body
+   * locates the current position; escalation advances to the next
+   * entry. When the current model is not on the ladder, or the ladder
+   * is exhausted, {@link nextLadderStep} returns `null` and the
+   * pipeline preserves the last attempted response.
+   */
+  readonly ladder: readonly string[];
+  /**
+   * Optional max-mode target. Required when `mode === 'max'`; unused
+   * in `ladder` mode. Issue #7 makes this operational.
+   */
+  readonly maxModel?: string;
+  /**
+   * Optional chorus endpoint. Required when `mode === 'chorus'`;
+   * unused in other modes. Issue #8 makes this operational.
+   */
+  readonly chorusEndpoint?: string;
+  /**
+   * Maximum number of escalation steps. `0` disables escalation
+   * (decisions are reported but no re-query happens). `1` allows one
+   * escalation and then freezes on whatever that produced. Per ADR-0018
+   * the recommended default is `2`.
+   */
+  readonly maxDepth: number;
+}
+
+/**
+ * Result of one escalation attempt, as recorded on the response headers
+ * and in the log line. Distinct from {@link OrchestratorDecision}: the
+ * orchestrator decides whether an escalation is warranted; the
+ * escalation result records what happened when the pipeline acted on
+ * that decision.
+ */
+export interface EscalationTrace {
+  /** The model ID each escalation step targeted, in order. */
+  readonly path: readonly string[];
+  /** Why the pipeline stopped escalating. */
+  readonly stoppedReason:
+    | 'passed'
+    | 'max_depth_reached'
+    | 'ladder_exhausted'
+    | 'model_not_on_ladder'
+    | 'not_attempted';
+  /** How many re-queries actually ran (0 when the first response passed). */
+  readonly depth: number;
+}

--- a/test/ladder.test.ts
+++ b/test/ladder.test.ts
@@ -16,9 +16,7 @@ describe('nextLadderStep', () => {
   });
 
   it('returns the next model from the middle of the ladder', () => {
-    expect(nextLadderStep('anthropic/claude-sonnet-4-6', ladder)).toBe(
-      'anthropic/claude-opus-4-7',
-    );
+    expect(nextLadderStep('anthropic/claude-sonnet-4-6', ladder)).toBe('anthropic/claude-opus-4-7');
   });
 
   it('returns null when the current model is the top rung', () => {

--- a/test/ladder.test.ts
+++ b/test/ladder.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { nextLadderStep, remainingLadderSteps } from '../src/escalation/ladder.js';
+
+describe('nextLadderStep', () => {
+  const ladder = [
+    'anthropic/claude-haiku-4-5',
+    'anthropic/claude-sonnet-4-6',
+    'anthropic/claude-opus-4-7',
+  ];
+
+  it('returns the next model when the current is at the bottom', () => {
+    expect(nextLadderStep('anthropic/claude-haiku-4-5', ladder)).toBe(
+      'anthropic/claude-sonnet-4-6',
+    );
+  });
+
+  it('returns the next model from the middle of the ladder', () => {
+    expect(nextLadderStep('anthropic/claude-sonnet-4-6', ladder)).toBe(
+      'anthropic/claude-opus-4-7',
+    );
+  });
+
+  it('returns null when the current model is the top rung', () => {
+    expect(nextLadderStep('anthropic/claude-opus-4-7', ladder)).toBeNull();
+  });
+
+  it('returns null when the current model is not on the ladder', () => {
+    expect(nextLadderStep('openai/gpt-4o', ladder)).toBeNull();
+  });
+
+  it('returns null for an empty ladder', () => {
+    expect(nextLadderStep('anything', [])).toBeNull();
+  });
+
+  it('is case-sensitive on model IDs', () => {
+    // Uppercase variant should not match the lowercase ladder entry.
+    expect(nextLadderStep('ANTHROPIC/CLAUDE-HAIKU-4-5', ladder)).toBeNull();
+  });
+
+  it('handles single-element ladders (top rung, no next)', () => {
+    expect(nextLadderStep('only-model', ['only-model'])).toBeNull();
+  });
+});
+
+describe('remainingLadderSteps', () => {
+  const ladder = ['a', 'b', 'c', 'd'];
+
+  it('counts steps above the bottom', () => {
+    expect(remainingLadderSteps('a', ladder)).toBe(3);
+  });
+
+  it('counts steps above the middle', () => {
+    expect(remainingLadderSteps('b', ladder)).toBe(2);
+  });
+
+  it('returns 0 at the top', () => {
+    expect(remainingLadderSteps('d', ladder)).toBe(0);
+  });
+
+  it('returns 0 for a model not on the ladder', () => {
+    expect(remainingLadderSteps('z', ladder)).toBe(0);
+  });
+
+  it('returns 0 for an empty ladder', () => {
+    expect(remainingLadderSteps('a', [])).toBe(0);
+  });
+});

--- a/test/pipeline-escalation.test.ts
+++ b/test/pipeline-escalation.test.ts
@@ -1,0 +1,387 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
+import type {
+  EscalationConfig,
+  OrchestratorConfig,
+  SignalWeights,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirror test/pipeline.test.ts)
+// ---------------------------------------------------------------------------
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  readonly baseUrl: string;
+  setHandler(handler: MockHandler): void;
+  /** Most recent received request bodies, in order. */
+  bodies(): readonly Buffer[];
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+  const seen: Buffer[] = [];
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      seen.push(body);
+      Promise.resolve(handler(req, res, body)).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end(`mock-error: ${String(err)}`);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}/v1`,
+    setHandler(h) {
+      handler = h;
+    },
+    bodies() {
+      return seen;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+const DEFAULT_WEIGHTS: SignalWeights = {
+  refusal: 1,
+  truncation: 1,
+  repetition: 1,
+  empty: 1,
+  tool_error: 1,
+  syntax_error: 1,
+};
+
+function makeOrchestratorConfig(
+  overrides: Partial<OrchestratorConfig> = {},
+): OrchestratorConfig {
+  return {
+    threshold: 0.6,
+    weights: DEFAULT_WEIGHTS,
+    greyBand: [0.3, 0.6] as const,
+    ...overrides,
+  };
+}
+
+function makeEscalationConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
+  return {
+    mode: 'ladder',
+    ladder: ['weak-model', 'mid-model', 'strong-model'],
+    maxDepth: 2,
+    ...overrides,
+  };
+}
+
+function buildChatCompletionBody(content: string, finishReason = 'stop'): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: finishReason,
+      },
+    ],
+  });
+}
+
+function readModelFromRequestBody(body: Buffer): string {
+  try {
+    const parsed = JSON.parse(body.toString('utf-8')) as Record<string, unknown>;
+    return typeof parsed['model'] === 'string' ? parsed['model'] : '';
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('pipeline escalation (ladder)', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig(),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  it('escalates from weak-model to mid-model when first response refuses, and stops on pass', async () => {
+    mock.setHandler((_req, res, body) => {
+      const model = readModelFromRequestBody(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else if (model === 'mid-model') {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      } else {
+        res.end(buildChatCompletionBody('unexpected model'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('1');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('mid-model');
+
+    const finalBody = await res.text();
+    expect(finalBody).toContain('clear, complete, helpful answer');
+
+    // Downstream should have been hit twice: weak-model (refusal) + mid-model (pass).
+    expect(mock.bodies()).toHaveLength(2);
+    expect(readModelFromRequestBody(mock.bodies()[0]!)).toBe('weak-model');
+    expect(readModelFromRequestBody(mock.bodies()[1]!)).toBe('mid-model');
+
+    expect(logs[0]?.escalation_depth).toBe(1);
+    expect(logs[0]?.escalation_stopped).toBe('passed');
+  });
+
+  it('stops at maxDepth=2 even when the last response is still inadequate', async () => {
+    // Every model returns a refusal; the loop should hit weak → mid → strong
+    // and then stop with max_depth_reached.
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help with that."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('2');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('max_depth_reached');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('mid-model,strong-model');
+    // The final body is whatever the last attempted model returned — here
+    // still a refusal, since every model refuses. That is by design
+    // (ADR-0017: the discarded earlier responses are not surfaced).
+    expect(mock.bodies()).toHaveLength(3);
+  });
+
+  it('stops with ladder_exhausted when the top rung refuses and no further steps exist', async () => {
+    // Use a ladder with only two rungs and maxDepth large enough that the
+    // limiting factor is the ladder, not the depth.
+    await sidecar.close();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          ladder: ['weak-model', 'top-model'],
+          maxDepth: 5,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help with that."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('ladder_exhausted');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('1');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('top-model');
+  });
+
+  it('does not escalate when the first response passes', async () => {
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Explain it briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
+    expect(mock.bodies()).toHaveLength(1);
+  });
+
+  it('reports model_not_on_ladder when the client-sent model is not in the configured ladder', async () => {
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'rogue-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('model_not_on_ladder');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
+    expect(mock.bodies()).toHaveLength(1);
+  });
+
+  it('does not escalate when mode is not ladder (e.g. max, not yet implemented in #6)', async () => {
+    await sidecar.close();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'max',
+          maxModel: 'unused-in-this-test',
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
+    expect(mock.bodies()).toHaveLength(1);
+  });
+
+  it('maxDepth: 0 disables escalation entirely', async () => {
+    await sidecar.close();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({ maxDepth: 0 }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
+    expect(mock.bodies()).toHaveLength(1);
+  });
+});

--- a/test/pipeline-escalation.test.ts
+++ b/test/pipeline-escalation.test.ts
@@ -4,11 +4,7 @@ import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
-import type {
-  EscalationConfig,
-  OrchestratorConfig,
-  SignalWeights,
-} from '../src/types.js';
+import type { EscalationConfig, OrchestratorConfig, SignalWeights } from '../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers (mirror test/pipeline.test.ts)
@@ -75,9 +71,7 @@ const DEFAULT_WEIGHTS: SignalWeights = {
   syntax_error: 1,
 };
 
-function makeOrchestratorConfig(
-  overrides: Partial<OrchestratorConfig> = {},
-): OrchestratorConfig {
+function makeOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
   return {
     threshold: 0.6,
     weights: DEFAULT_WEIGHTS,


### PR DESCRIPTION
Closes issue 6.

Adds the ladder escalation strategy: when the orchestrator decides
escalate, the pipeline re-queries with the next model on the configured
ladder until the response passes, the ladder is exhausted, or maxDepth
is reached (default 2). Client sees the final attempted answer; headers
(`X-Turbocharger-Escalation-Depth`, `-Stopped`, `-Path`) record what
happened. Original inadequate responses are discarded per ADR-0017.

## Commits

Five commits. Three feat/test/docs, one prettier chore, one fix caught
by the integration tests on first run.

- **feat(escalation)** — types, `nextLadderStep` pure function,
  pipeline escalation loop, server wiring.
- **test(escalation)** — 12 ladder unit tests + 7 pipeline integration
  tests covering pass-first, maxDepth exhaustion, ladder exhaustion,
  model-not-on-ladder, non-ladder mode, and maxDepth=0 behaviour.
- **docs** — ADR-0016 (flat ladder against single downstream),
  ADR-0017 (original responses discarded), ADR-0018 (default
  maxDepth is 2).
- **chore** — Prettier normalization across the 6 files Prettier
  chose to reformat.
- **fix(pipeline)** — the post-loop reconciliation block overwrote
  the `model_not_on_ladder` stoppedReason with `not_attempted`.
  Removed the reconciliation block; initialize correctly up front
  and let every loop exit path set its own final value.

## Verification

`pnpm check` green: 112 passed / 3 todo, format clean, lint clean,
typecheck clean, build succeeds. `dist/server.js` grew from 19.30 KB
to 23.04 KB — the escalation loop and header-annotation logic are
now in the server entry point, reachable whenever both
`orchestratorConfig` and `escalationConfig` are supplied.

## Not in this PR

- Max-mode (issue 7) and chorus dispatch (issue 8). The type surface
  admits both values; the pipeline treats them as "no escalation".
- Body-level transparency (issues 9, 10).
- Per-request overrides via `X-Turbocharger-Mode` header (issue 12).
- Zod-validated config loading (issue 11).