### PR TITLE
feat(escalation): max strategy (issue 7, ADR-0019)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -841,3 +841,50 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
 - **Related:** issue #6 (this ADR); issue #11 will introduce the
   Zod schema that materializes the default in the validated config
   loader.
+
+## ADR-0019: Max-mode requires an explicit maxModel, and respects maxDepth
+
+- **Date:** 2026-04-21
+- **Status:** accepted
+- **Decision:** When `EscalationConfig.mode === 'max'`, the pipeline
+  resolves the target model exclusively from `config.maxModel`. If
+  `maxModel` is unset or an empty string, the pipeline records
+  `stoppedReason: 'max_model_not_set'` and performs no re-query. Max-
+  mode also respects `maxDepth`: `maxDepth === 0` disables escalation
+  for any mode, keeping the "kill switch" semantics uniform between
+  ladder and max.
+- **Rationale:** The point of max-mode is "skip straight to the
+  configured best model when the first attempt is inadequate". If the
+  best model is not configured, the correct response is to surface
+  the configuration gap, not to invent a fallback. A hidden fallback
+  (e.g. "use the top of `ladder` when `maxModel` is unset") would
+  degrade a configuration error into silently different behaviour:
+  users would see max-mode responses that look like ladder responses,
+  with no clear signal that they had forgotten to set `maxModel`.
+  Propagating `max_model_not_set` through the trace makes the
+  configuration mistake loud and auditable. The `maxDepth` decision
+  is pragmatic consistency: a single mental model ("maxDepth gates
+  all escalation, regardless of mode") is easier to reason about at
+  the config level than "maxDepth means N for ladder but always 1
+  for max", and max-mode users who want the single-jump behaviour
+  can leave `maxDepth` at its default (2) or set it to 1 — the extra
+  budget for max-mode is unused and harmless, since max performs
+  exactly one jump by construction.
+- **Alternatives considered:**
+  - _Fall back to the top of `ladder` when `maxModel` is unset._
+    Rejected: hides a configuration error by producing ladder-like
+    output in a max-mode deployment. Users would not realize the
+    config is wrong until someone audited the actual flow.
+  - _Make max-mode ignore `maxDepth` and always jump once._ Rejected:
+    breaks the "maxDepth is the uniform kill switch" guarantee that
+    makes it easy to disable all escalation for debugging or
+    rollback scenarios. The minor inconvenience of a user setting
+    `maxDepth: 1` for a strict single-jump max is worth the
+    conceptual consistency.
+  - _Fall back to some well-known provider default (e.g. "gpt-4")._
+    Rejected: any baked-in default is a business-relationship
+    assumption we should not make on behalf of the user.
+- **Related:** issue #7; ADR-0016 (ladder and max both address a
+  single downstream); ADR-0018 (maxDepth default is 2, which
+  continues to be the recommended default for max-mode too despite
+  max using at most one of those two available slots).

--- a/src/escalation/index.ts
+++ b/src/escalation/index.ts
@@ -1,10 +1,12 @@
 // Escalation module barrel.
 //
-// Issue #6 exposes the ladder strategy as a pure function. Issues #7
-// (max) and #8 (chorus-stub) will add their own strategy modules here.
-// The pipeline (src/pipeline.ts) selects the active strategy from the
-// configured {@link EscalationConfig.mode} and calls the strategy's
-// pure helpers to compute the next model. The pipeline itself owns the
+// Issue #6 exposed the ladder strategy. Issue #7 adds the max
+// strategy (one-shot jump to a configured `maxModel`). Issue #8
+// (chorus-stub) will add its own strategy module here. The pipeline
+// (src/pipeline.ts) selects the active strategy from the configured
+// {@link EscalationConfig.mode} and calls the strategy's pure
+// helpers to compute the next model. The pipeline itself owns the
 // re-query loop so the strategy modules stay stateless and testable.
 
 export { nextLadderStep, remainingLadderSteps } from './ladder.js';
+export { maxStep } from './max.js';

--- a/src/escalation/max.ts
+++ b/src/escalation/max.ts
@@ -1,4 +1,40 @@
-// TODO(issue #7): Max strategy.
-// Jump directly to the user-defined max_model. No intermediate steps.
+// Max escalation strategy: jump directly to a user-configured
+// "maximum performance" model when the orchestrator (issue #5) signals
+// that the current model's answer is inadequate. No intermediate
+// ladder steps — one re-query, then stop.
+//
+// Scope (v0.1, issue #7):
+//   - Pure function {@link maxStep} that returns the configured
+//     `maxModel` when set, or `null` when the caller has selected
+//     max-mode without supplying a maxModel.
+//   - The pipeline (src/pipeline.ts) owns the re-query logic and the
+//     stopping condition; this module only resolves the target model.
+//   - Per ADR-0019, max-mode respects `maxDepth`: when `maxDepth` is
+//     0 the max-mode strategy is disabled just like ladder-mode. The
+//     pipeline enforces that; this module does not read `maxDepth`.
+//
+// Intentionally NOT in this file:
+//   - The re-query / orchestrator loop — pipeline.ts handles it.
+//   - Per-model baseUrl / apiKey — shared with ladder per ADR-0016.
+//     v0.1 addresses every mode's target at the single configured
+//     downstream ProxyTarget.
+//   - A fallback to the top of `ladder` when `maxModel` is unset —
+//     deliberately omitted per ADR-0019 to make missing configuration
+//     loud rather than silent.
 
-export {};
+import type { EscalationConfig } from '../types.js';
+
+/**
+ * Resolve the target model for a max-mode escalation.
+ *
+ * Returns `config.maxModel` when set, otherwise `null`. A `null`
+ * result means the caller has a configuration error (mode is 'max'
+ * but no maxModel was supplied) and the pipeline should treat the
+ * escalation as not-attempted rather than invent a fallback target.
+ */
+export function maxStep(config: EscalationConfig): string | null {
+  if (config.maxModel === undefined || config.maxModel.length === 0) {
+    return null;
+  }
+  return config.maxModel;
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -32,6 +32,7 @@
 
 import { runOrchestrator } from './critic/orchestrator.js';
 import { nextLadderStep } from './escalation/ladder.js';
+import { maxStep } from './escalation/max.js';
 import { forwardChatCompletion } from './proxy.js';
 import type {
   EscalationConfig,
@@ -336,25 +337,38 @@ export async function runPipeline(
   // Escalation loop. Runs only when:
   //   - the orchestrator decided `escalate`,
   //   - an escalation config is provided,
-  //   - the mode is `ladder` (other modes fall through untouched; issues #7/#8),
+  //   - the mode is `ladder` or `max` (chorus falls through; issue #8),
   //   - `maxDepth` has not yet been spent,
-  //   - a next ladder step exists.
+  //   - a next target model can be resolved (strategy-specific).
   while (
     currentDecision.kind === 'escalate' &&
     escalationConfig !== undefined &&
-    escalationConfig.mode === 'ladder' &&
+    (escalationConfig.mode === 'ladder' || escalationConfig.mode === 'max') &&
     depth < escalationConfig.maxDepth
   ) {
-    const next = nextLadderStep(currentModel, escalationConfig.ladder);
-    if (next === null) {
-      // Current model isn't on the ladder, or we're at the top. Stop
-      // with an informative reason so monitors can distinguish the two
-      // off-ladder cases from actual ladder exhaustion.
-      stoppedReason =
-        escalationConfig.ladder.indexOf(currentModel) === -1
-          ? 'model_not_on_ladder'
-          : 'ladder_exhausted';
-      break;
+    // Strategy dispatch: resolve the next target model. Ladder walks
+    // one rung; max returns the configured maxModel (once) or null
+    // when it is unset. Per ADR-0019, a null from maxStep is a
+    // configuration error, not a silent fallback to another strategy.
+    let next: string | null;
+    if (escalationConfig.mode === 'max') {
+      next = maxStep(escalationConfig);
+      if (next === null) {
+        stoppedReason = 'max_model_not_set';
+        break;
+      }
+    } else {
+      next = nextLadderStep(currentModel, escalationConfig.ladder);
+      if (next === null) {
+        // Current model isn't on the ladder, or we're at the top. Stop
+        // with an informative reason so monitors can distinguish the two
+        // off-ladder cases from actual ladder exhaustion.
+        stoppedReason =
+          escalationConfig.ladder.indexOf(currentModel) === -1
+            ? 'model_not_on_ladder'
+            : 'ladder_exhausted';
+        break;
+      }
     }
 
     path.push(next);
@@ -397,6 +411,15 @@ export async function runPipeline(
       break;
     }
     if (depth >= escalationConfig.maxDepth) {
+      stoppedReason = 'max_depth_reached';
+      break;
+    }
+    // Max mode does exactly one re-query per invocation: after the
+    // orchestrator evaluates the re-queried response, there is no
+    // further target to escalate to. If the decision is still
+    // `escalate`, we stop with max_depth_reached (semantically:
+    // "we used the one jump we had").
+    if (escalationConfig.mode === 'max') {
       stoppedReason = 'max_depth_reached';
       break;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,6 +387,7 @@ export interface EscalationTrace {
     | 'max_depth_reached'
     | 'ladder_exhausted'
     | 'model_not_on_ladder'
+    | 'max_model_not_set'
     | 'not_attempted';
   /** How many re-queries actually ran (0 when the first response passed). */
   readonly depth: number;

--- a/test/max.test.ts
+++ b/test/max.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { maxStep } from '../src/escalation/max.js';
+import type { EscalationConfig } from '../src/types.js';
+
+function makeConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
+  return {
+    mode: 'max',
+    ladder: [],
+    maxDepth: 1,
+    ...overrides,
+  };
+}
+
+describe('maxStep', () => {
+  it('returns maxModel when it is set', () => {
+    expect(maxStep(makeConfig({ maxModel: 'anthropic/claude-opus-4-7' }))).toBe(
+      'anthropic/claude-opus-4-7',
+    );
+  });
+
+  it('returns null when maxModel is undefined', () => {
+    expect(maxStep(makeConfig())).toBeNull();
+  });
+
+  it('returns null when maxModel is an empty string', () => {
+    // Empty string reflects a caller who built the config imperatively
+    // and accidentally assigned '' — we do not want to treat that as
+    // a valid target.
+    expect(maxStep(makeConfig({ maxModel: '' }))).toBeNull();
+  });
+
+  it('is agnostic to ladder contents', () => {
+    // Max-mode is deliberately not a "top-of-ladder" fallback: the
+    // function reads maxModel and only maxModel. A non-empty ladder
+    // with an unset maxModel still yields null.
+    expect(
+      maxStep(
+        makeConfig({
+          ladder: ['weak', 'mid', 'strong'],
+          // maxModel intentionally omitted
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns maxModel even when ladder is empty', () => {
+    expect(
+      maxStep(
+        makeConfig({
+          ladder: [],
+          maxModel: 'only-model',
+        }),
+      ),
+    ).toBe('only-model');
+  });
+});

--- a/test/pipeline-escalation.test.ts
+++ b/test/pipeline-escalation.test.ts
@@ -305,7 +305,7 @@ describe('pipeline escalation (ladder)', () => {
     expect(mock.bodies()).toHaveLength(1);
   });
 
-  it('does not escalate when mode is not ladder (e.g. max, not yet implemented in #6)', async () => {
+  it('does not escalate when mode is chorus (not yet implemented in issue 6 or 7)', async () => {
     await sidecar.close();
     logs = [];
     sidecar = startServer(
@@ -316,8 +316,8 @@ describe('pipeline escalation (ladder)', () => {
         },
         orchestratorConfig: makeOrchestratorConfig(),
         escalationConfig: makeEscalationConfig({
-          mode: 'max',
-          maxModel: 'unused-in-this-test',
+          mode: 'chorus',
+          chorusEndpoint: 'http://example.test/unused',
         }),
       },
     );
@@ -376,6 +376,227 @@ describe('pipeline escalation (ladder)', () => {
     expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
     expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
     expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
+    expect(mock.bodies()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Max-mode (issue #7)
+// ---------------------------------------------------------------------------
+
+describe('pipeline escalation (max)', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'max',
+          ladder: [],
+          maxModel: 'strong-model',
+          maxDepth: 1,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  it('jumps directly to maxModel when the first response refuses, and stops on pass', async () => {
+    mock.setHandler((_req, res, body) => {
+      const model = readModelFromRequestBody(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, I cannot help with that."));
+      } else if (model === 'strong-model') {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      } else {
+        res.end(buildChatCompletionBody('unexpected model'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('1');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('strong-model');
+
+    const finalBody = await res.text();
+    expect(finalBody).toContain('clear, complete, helpful answer');
+
+    // Exactly two downstream hits: weak-model (initial), strong-model (the jump).
+    expect(mock.bodies()).toHaveLength(2);
+    expect(readModelFromRequestBody(mock.bodies()[0]!)).toBe('weak-model');
+    expect(readModelFromRequestBody(mock.bodies()[1]!)).toBe('strong-model');
+
+    expect(logs[0]?.escalation_depth).toBe(1);
+    expect(logs[0]?.escalation_stopped).toBe('passed');
+  });
+
+  it('stops after the single jump even when maxModel also refuses', async () => {
+    // Every model returns a refusal. Max-mode gets exactly one jump,
+    // and after the jump response is evaluated and still fails, the
+    // loop must stop with max_depth_reached rather than try anything
+    // else. No top-of-ladder fallback, no second max invocation.
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help with that."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('1');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('max_depth_reached');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('strong-model');
+    expect(mock.bodies()).toHaveLength(2);
+  });
+
+  it('reports max_model_not_set when mode is max but maxModel is unset', async () => {
+    await sidecar.close();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'max',
+          ladder: [],
+          maxDepth: 1,
+          // maxModel intentionally omitted
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('max_model_not_set');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
+    // Exactly one downstream call: the initial request. No re-query
+    // because the configuration was invalid.
+    expect(mock.bodies()).toHaveLength(1);
+  });
+
+  it('does not escalate when the first response passes', async () => {
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Explain it briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
+    expect(mock.bodies()).toHaveLength(1);
+  });
+
+  it('respects maxDepth=0 and does not invoke the max jump', async () => {
+    await sidecar.close();
+    logs = [];
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'max',
+          ladder: [],
+          maxModel: 'strong-model',
+          maxDepth: 0,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
     expect(mock.bodies()).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes issue 7.

Adds the second escalation strategy: max-mode, which re-queries the
downstream once with a configured `maxModel` and then stops regardless
of whether that response passes. Complements ladder-mode (issue 6).

## Commits

Three: feat, test, docs. Two modes now share the same re-query loop
in the pipeline, with a strategy dispatch for target-model resolution.

## Verification

`pnpm check` green locally.

## Not in this PR

- Chorus dispatch (issue 8, stub only) — still a no-op; the pipeline
  loop skips mode='chorus'.
- Body-level transparency (issues 9, 10).
- Per-request mode override via X-Turbocharger-Mode header (issue 12).

## README update

The README "6 of 15 merged" line is still from PR #10. I chose not to
bump it to "7 of 15" in this PR to keep the diff tightly focused on
the code change. A small follow-up PR or the next feature PR can bump
it to 7.