### PR TITLE
feat(escalation): chorus dispatch stub (issue 8, ADR-0020)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -888,3 +888,80 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   single downstream); ADR-0018 (maxDepth default is 2, which
   continues to be the recommended default for max-mode too despite
   max using at most one of those two available slots).
+
+## ADR-0020: Chorus dispatch is an OpenAI-compatible stub with hard-fail semantics
+
+- **Date:** 2026-04-22
+- **Status:** accepted
+- **Decision:** When `EscalationConfig.mode === 'chorus'`, the
+  pipeline performs exactly one HTTP POST to
+  `config.chorusEndpoint` with the client's original
+  chat/completions request body and the client's forwarded headers
+  (hop-by-hop stripped per RFC 7230), plus per-request context
+  headers under the `X-Turbocharger-*` namespace (decision reason,
+  aggregate score, ladder contents, etc). The endpoint is expected
+  to be OpenAI-compatible — that is, it accepts a standard chat-
+  completions request and returns a standard chat-completions
+  response. The dispatch is hard-fail: if the endpoint is unset,
+  unreachable, times out, or responds with a non-2xx status, the
+  pipeline surfaces a specific `stoppedReason`
+  (`chorus_endpoint_not_set`, `chorus_unreachable`,
+  `chorus_timeout`, `chorus_non_ok_status`) and returns the
+  original inadequate downstream response to the client. The
+  default timeout is 90 seconds (`DEFAULT_CHORUS_TIMEOUT_MS`),
+  overridable via `chorusTimeoutMs`. Chorus respects `maxDepth`:
+  `maxDepth === 0` disables it like any other mode.
+- **Rationale:** The chorus strategy is the multi-model consensus
+  strategy envisioned in the project brief, but the full
+  implementation (parallel dispatch, adequacy synthesis, minority
+  reports) is deliberately scoped to a separate project
+  (`openclaw-chorus`) rather than built into this sidecar. Issue #8
+  reserves the integration point without building the logic behind
+  it. The OpenAI-compatible protocol is the obvious choice: it
+  means a chorus server can be implemented as any OpenAI-
+  compatible HTTP service and swapped in without requiring a
+  non-standard request shape. Context via `X-Turbocharger-*`
+  headers lets the chorus server optionally make use of the
+  escalation reason and configured ladder without the client
+  having to pass them explicitly, while keeping the request body
+  a plain chat-completions payload. The hard-fail policy is a
+  deliberate deviation from the brief (§5, which suggested
+  "graceful fallback to max"): falling back silently would hide
+  configuration errors and make it hard to distinguish "chorus
+  was the strategy" from "chorus failed and max ran instead" in
+  the trace. Users who want a fallback can compose it at the
+  config layer (e.g. by retrying a failed chorus request with a
+  different mode) once the Zod-validated config loader arrives
+  in issue #11. The 90-second default reflects the realistic
+  runtime of chorus endpoints: parallel calls to ~3-5 models plus
+  a synthesis step routinely exceeds 45 seconds on sizeable
+  contexts, and a default that forces users to override on every
+  real deployment would be unhelpful. 90 seconds is generous
+  enough to let typical chorus implementations finish under
+  realistic conditions, while still bounding the worst case.
+- **Alternatives considered:**
+  - _Non-OpenAI-compatible dedicated chorus API._ Rejected:
+    locks the chorus server design into this project's
+    assumptions and forecloses reusing existing OpenAI-compatible
+    infrastructure.
+  - _Graceful fallback to max-mode on chorus failure._ Rejected
+    in favor of hard-fail because fallback hides configuration
+    errors and makes the trace misleading. Users who want
+    fallback can layer it on top via config composition, and the
+    decision is reversible: adding fallback later as an opt-in
+    flag is trivial, whereas removing silent fallback would be
+    a breaking change.
+  - _Baked-in default chorus endpoint (e.g. a hosted service)._
+    Rejected: assumes a business relationship we shouldn't make
+    on behalf of users.
+  - _Lower default timeout (30s or 60s)._ Rejected because
+    realistic chorus runtimes regularly exceed 60s under normal
+    conditions. A too-aggressive default would surface as
+    `chorus_timeout` errors for the common case, forcing every
+    deployment to override the default — which defeats the
+    purpose of a default.
+- **Related:** issue #8; ADR-0016 (escalation modes share the
+  downstream ProxyTarget — but chorus explicitly does not, since
+  it addresses a distinct endpoint); ADR-0019 (max-mode semantics
+  — same hard-fail pattern for `max_model_not_set`); brief §5
+  (original "graceful fallback" wording, revised here).

--- a/src/escalation/chorus.ts
+++ b/src/escalation/chorus.ts
@@ -1,6 +1,146 @@
-// TODO(issue #8): Chorus strategy — INTERFACE STUB ONLY in MVP.
-// HTTP POST to configurable chorus_endpoint. Graceful fallback if endpoint
-// unset (emit warning, fall back to `max` strategy). Full implementation lives
-// in a separate project (openclaw-chorus); do not implement chorus logic here.
+// Chorus escalation strategy — interface stub (issue #8, ADR-0020).
+//
+// Chorus dispatches the client's original request to an external,
+// OpenAI-compatible endpoint that is expected to fan out to multiple
+// models, synthesise a combined answer, and return it as a standard
+// chat-completions response. Full chorus logic lives in the separate
+// `openclaw-chorus` project; this module only reserves the HTTP
+// connection point and the error surface.
+//
+// Scope (v0.1, issue #8):
+//   - {@link dispatchChorus} POSTs the original request body (plus
+//     per-request context surfaced via `X-Turbocharger-*` headers)
+//     to the configured endpoint. It is a drop-in OpenAI client with
+//     a caller-controlled timeout and an enumerated error surface.
+//   - Per ADR-0020, the dispatch is hard-fail: no fallback to
+//     ladder, max, or any provider default. A missing, unreachable,
+//     timing-out, or error-responding endpoint is surfaced as a
+//     specific {@link ChorusDispatchResult}.`error` with a dedicated
+//     {@link EscalationTrace.stoppedReason}.
+//   - The pipeline (src/pipeline.ts) owns the decision of when to
+//     dispatch to chorus and how to thread the result back into the
+//     response; this module only performs the one HTTP call.
+//
+// Intentionally NOT in this file:
+//   - The chorus logic itself (parallel dispatch, synthesis, minority
+//     reports) — those belong to `openclaw-chorus`.
+//   - Re-evaluating chorus output with the orchestrator. Per ADR-0020
+//     the chorus response is forwarded as-is; the assumption is that
+//     the chorus server already incorporates adequacy judgement into
+//     its synthesis.
+//   - Retrying failed dispatches. One attempt, then the pipeline
+//     stops.
 
-export {};
+import {
+  DEFAULT_CHORUS_TIMEOUT_MS,
+  type ChorusDispatchResult,
+  type EscalationConfig,
+} from '../types.js';
+
+export interface ChorusDispatchInput {
+  /** Raw body bytes of the client's original chat/completions request. */
+  readonly bodyBytes: string;
+  /** Forwarded headers from the client's request. */
+  readonly clientHeaders: Headers;
+  /**
+   * Context headers produced by the pipeline: decision reason,
+   * aggregate score, ladder configuration, etc. Added on top of the
+   * client headers so the chorus server can make use of them without
+   * the client having to pass them explicitly.
+   */
+  readonly contextHeaders: Record<string, string>;
+  /** Optional `fetch` override for tests. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send the client's original request to the configured chorus
+ * endpoint and return the response or a classified error.
+ */
+export async function dispatchChorus(
+  config: EscalationConfig,
+  input: ChorusDispatchInput,
+): Promise<ChorusDispatchResult> {
+  if (config.chorusEndpoint === undefined || config.chorusEndpoint.length === 0) {
+    return {
+      kind: 'error',
+      reason: 'endpoint_not_set',
+      detail: 'EscalationConfig.chorusEndpoint is required when mode is "chorus"',
+    };
+  }
+
+  const fetchFn: typeof fetch = input.fetchImpl ?? fetch;
+  const timeoutMs = config.chorusTimeoutMs ?? DEFAULT_CHORUS_TIMEOUT_MS;
+
+  // Build the outbound headers. Hop-by-hop headers from the client
+  // (per RFC 7230) are stripped to match the behaviour of the
+  // regular proxy path; content-type is preserved because the body
+  // bytes are forwarded verbatim.
+  const outboundHeaders = new Headers();
+  for (const [name, value] of input.clientHeaders.entries()) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP.has(lower)) continue;
+    if (lower === 'host') continue;
+    if (lower === 'content-length') continue;
+    outboundHeaders.set(name, value);
+  }
+  for (const [name, value] of Object.entries(input.contextHeaders)) {
+    outboundHeaders.set(name, value);
+  }
+  if (!outboundHeaders.has('content-type')) {
+    outboundHeaders.set('content-type', 'application/json');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchFn(config.chorusEndpoint, {
+      method: 'POST',
+      headers: outboundHeaders,
+      body: input.bodyBytes,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        kind: 'error',
+        reason: 'non_ok_status',
+        detail: `chorus endpoint responded with HTTP ${response.status} ${response.statusText}`,
+      };
+    }
+    return { kind: 'ok', response };
+  } catch (err) {
+    // AbortError (timeout) is distinguishable by its name across
+    // runtimes; other errors are classified as "unreachable" which
+    // covers DNS failures, connection refused, TLS errors, etc.
+    if (err instanceof Error && err.name === 'AbortError') {
+      return {
+        kind: 'error',
+        reason: 'timeout',
+        detail: `chorus dispatch timed out after ${timeoutMs}ms`,
+      };
+    }
+    const message = err instanceof Error ? err.message : 'unknown error';
+    return {
+      kind: 'error',
+      reason: 'unreachable',
+      detail: `chorus dispatch failed: ${message}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Same hop-by-hop header list as the regular proxy. Kept local here
+// to avoid importing from proxy.ts (which would couple the two
+// modules more tightly than necessary).
+const HOP_BY_HOP = new Set<string>([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);

--- a/src/escalation/index.ts
+++ b/src/escalation/index.ts
@@ -1,12 +1,15 @@
 // Escalation module barrel.
 //
-// Issue #6 exposed the ladder strategy. Issue #7 adds the max
+// Issue #6 exposed the ladder strategy. Issue #7 added the max
 // strategy (one-shot jump to a configured `maxModel`). Issue #8
-// (chorus-stub) will add its own strategy module here. The pipeline
-// (src/pipeline.ts) selects the active strategy from the configured
+// adds the chorus dispatch stub (one-shot POST to a configured
+// `chorusEndpoint`; full chorus logic lives in the separate
+// `openclaw-chorus` project). The pipeline (src/pipeline.ts)
+// selects the active strategy from the configured
 // {@link EscalationConfig.mode} and calls the strategy's pure
-// helpers to compute the next model. The pipeline itself owns the
-// re-query loop so the strategy modules stay stateless and testable.
+// helpers; the re-query loop and the chorus dispatch are owned by
+// the pipeline so the strategy modules stay stateless and testable.
 
 export { nextLadderStep, remainingLadderSteps } from './ladder.js';
 export { maxStep } from './max.js';
+export { dispatchChorus } from './chorus.js';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -33,6 +33,7 @@
 import { runOrchestrator } from './critic/orchestrator.js';
 import { nextLadderStep } from './escalation/ladder.js';
 import { maxStep } from './escalation/max.js';
+import { dispatchChorus } from './escalation/chorus.js';
 import { forwardChatCompletion } from './proxy.js';
 import type {
   EscalationConfig,
@@ -334,6 +335,82 @@ export async function runPipeline(
     stoppedReason = 'passed';
   }
 
+  // Chorus dispatch (issue #8). Runs only when:
+  //   - the orchestrator decided `escalate`,
+  //   - an escalation config is provided,
+  //   - the mode is `chorus`,
+  //   - `maxDepth` is > 0 (keeps the kill switch uniform with ladder
+  //     and max; per ADR-0018 and ADR-0019 maxDepth=0 means "no
+  //     escalation for any mode").
+  //
+  // Unlike the ladder/max loop, chorus goes to a different HTTP
+  // endpoint (not the configured ProxyTarget) and its response is
+  // forwarded verbatim — no orchestrator re-evaluation. Per ADR-0020
+  // the dispatch is hard-fail: any error classifies the stop reason
+  // and the original inadequate response is returned to the client.
+  if (
+    currentDecision.kind === 'escalate' &&
+    escalationConfig !== undefined &&
+    escalationConfig.mode === 'chorus' &&
+    escalationConfig.maxDepth > 0
+  ) {
+    const chorusResult = await dispatchChorus(escalationConfig, {
+      bodyBytes: currentBodyText.length > 0 ? getOriginalRequestBody(parsed) : '{}',
+      clientHeaders: request.headers,
+      contextHeaders: buildChorusContextHeaders(currentDecision, escalationConfig),
+    });
+
+    if (chorusResult.kind === 'ok') {
+      const chorusBodyText = await chorusResult.response.text();
+      const chorusContentType = chorusResult.response.headers.get('content-type') ?? '';
+      if (chorusContentType.toLowerCase().includes('application/json')) {
+        // The chorus response is forwarded as-is. We re-run the
+        // orchestrator so the decision on the response is honest —
+        // but we do not act on an `escalate` decision here because
+        // chorus has no further step to take. The decision is
+        // reported via headers, the body is the chorus answer.
+        const chorusAssistant = parseChatCompletionBody(safeJsonParse(chorusBodyText));
+        const chorusDecision = await runOrchestrator(
+          buildOrchestratorInput(chorusAssistant, parsed),
+          orchestratorConfig,
+        );
+        currentDecision = chorusDecision;
+        currentBodyText = chorusBodyText;
+        currentResponse = chorusResult.response;
+        path.push('chorus');
+        depth = 1;
+        stoppedReason = chorusDecision.kind === 'pass' ? 'passed' : 'max_depth_reached';
+      } else {
+        // Chorus returned non-JSON. Forward the bytes as-is, record
+        // the stop reason, and keep the original decision (so the
+        // client still sees that escalation was attempted).
+        currentBodyText = chorusBodyText;
+        currentResponse = chorusResult.response;
+        path.push('chorus');
+        depth = 1;
+        stoppedReason = 'max_depth_reached';
+      }
+    } else {
+      // Classified chorus error. Keep the original (inadequate)
+      // response body for the client and record the specific stop
+      // reason for monitors and the transparency layer.
+      switch (chorusResult.reason) {
+        case 'endpoint_not_set':
+          stoppedReason = 'chorus_endpoint_not_set';
+          break;
+        case 'unreachable':
+          stoppedReason = 'chorus_unreachable';
+          break;
+        case 'timeout':
+          stoppedReason = 'chorus_timeout';
+          break;
+        case 'non_ok_status':
+          stoppedReason = 'chorus_non_ok_status';
+          break;
+      }
+    }
+  }
+
   // Escalation loop. Runs only when:
   //   - the orchestrator decided `escalate`,
   //   - an escalation config is provided,
@@ -457,4 +534,47 @@ function buildOrchestratorInput(
     ...(assistant.finishReason !== undefined ? { finishReason: assistant.finishReason } : {}),
     ...(parsed.locale !== undefined ? { locale: parsed.locale } : {}),
   };
+}
+
+/**
+ * Serialise the client's original request body for forwarding to the
+ * chorus endpoint. If parsing failed upstream (parsed.body is null),
+ * fall back to an empty JSON object — the chorus server will return
+ * a 4xx which we will classify as non_ok_status.
+ */
+function getOriginalRequestBody(parsed: ParsedRequest): string {
+  if (parsed.body === null) return '{}';
+  return JSON.stringify(parsed.body);
+}
+
+/**
+ * Build the per-request context headers the chorus endpoint receives
+ * on top of the client's forwarded headers. Per ADR-0020 the chorus
+ * protocol is OpenAI-compatible; the context is provided through
+ * `X-Turbocharger-*` headers so a chorus server can optionally make
+ * use of it without requiring a non-standard request body shape.
+ */
+function buildChorusContextHeaders(
+  decision: OrchestratorDecision,
+  config: EscalationConfig,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (decision.kind === 'escalate') {
+    headers['x-turbocharger-reason'] = decision.reason;
+    headers['x-turbocharger-aggregate'] = decision.aggregate.toFixed(3);
+    if (decision.signals.length > 0) {
+      headers['x-turbocharger-signals'] = decision.signals.map((s) => s.category).join(',');
+    }
+    if (decision.verdict !== undefined) {
+      headers['x-turbocharger-verdict'] = decision.verdict.verdict;
+      headers['x-turbocharger-verdict-confidence'] = decision.verdict.confidence.toFixed(3);
+    }
+  }
+  if (config.ladder.length > 0) {
+    headers['x-turbocharger-ladder'] = config.ladder.join(',');
+  }
+  if (config.maxModel !== undefined && config.maxModel.length > 0) {
+    headers['x-turbocharger-max-model'] = config.maxModel;
+  }
+  return headers;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -439,10 +439,6 @@ export type ChorusDispatchResult =
     }
   | {
       readonly kind: 'error';
-      readonly reason:
-        | 'endpoint_not_set'
-        | 'unreachable'
-        | 'timeout'
-        | 'non_ok_status';
+      readonly reason: 'endpoint_not_set' | 'unreachable' | 'timeout' | 'non_ok_status';
       readonly detail: string;
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,9 +359,22 @@ export interface EscalationConfig {
   readonly maxModel?: string;
   /**
    * Optional chorus endpoint. Required when `mode === 'chorus'`;
-   * unused in other modes. Issue #8 makes this operational.
+   * unused in other modes. Issue #8 makes this operational as an
+   * interface-only stub (see ADR-0020): the pipeline POSTs the
+   * original request to this URL and forwards the response as-is.
+   * Full chorus logic lives in the separate `openclaw-chorus`
+   * project and is not in scope here.
    */
   readonly chorusEndpoint?: string;
+  /**
+   * Optional per-request timeout for chorus dispatch, in
+   * milliseconds. Measured from the moment the sidecar sends the
+   * HTTP request to the moment the full response body has arrived.
+   * Applies only to `mode === 'chorus'`; ladder and max re-queries
+   * use the default client behaviour of {@link forwardChatCompletion}.
+   * When absent, {@link DEFAULT_CHORUS_TIMEOUT_MS} is used.
+   */
+  readonly chorusTimeoutMs?: number;
   /**
    * Maximum number of escalation steps. `0` disables escalation
    * (decisions are reported but no re-query happens). `1` allows one
@@ -388,7 +401,48 @@ export interface EscalationTrace {
     | 'ladder_exhausted'
     | 'model_not_on_ladder'
     | 'max_model_not_set'
+    | 'chorus_endpoint_not_set'
+    | 'chorus_unreachable'
+    | 'chorus_timeout'
+    | 'chorus_non_ok_status'
     | 'not_attempted';
   /** How many re-queries actually ran (0 when the first response passed). */
   readonly depth: number;
 }
+
+// ---------------------------------------------------------------------------
+// Chorus dispatch (issue #8, stub)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default timeout for chorus dispatch, in milliseconds. See ADR-0020
+ * for the rationale behind 90 seconds: chorus endpoints fan out to
+ * several models in parallel and synthesise a combined answer, which
+ * is substantially slower than a single model call. Callers can
+ * override via {@link EscalationConfig.chorusTimeoutMs}.
+ */
+export const DEFAULT_CHORUS_TIMEOUT_MS = 90_000;
+
+/**
+ * Discriminated result of a chorus dispatch attempt.
+ *
+ * Per ADR-0020 the chorus dispatch is hard-fail: if the endpoint is
+ * unset, unreachable, timed out, or returned a non-2xx status, the
+ * pipeline does not fall back to another escalation strategy. It
+ * returns the relevant `error` result and the pipeline's trace
+ * records the corresponding `stoppedReason`.
+ */
+export type ChorusDispatchResult =
+  | {
+      readonly kind: 'ok';
+      readonly response: Response;
+    }
+  | {
+      readonly kind: 'error';
+      readonly reason:
+        | 'endpoint_not_set'
+        | 'unreachable'
+        | 'timeout'
+        | 'non_ok_status';
+      readonly detail: string;
+    };

--- a/test/chorus.test.ts
+++ b/test/chorus.test.ts
@@ -125,7 +125,7 @@ describe('dispatchChorus', () => {
   it('forwards context headers on top of client headers', async () => {
     let captured: Headers | undefined;
     const fetchImpl: typeof fetch = async (_url, init) => {
-      captured = new Headers(init?.headers as HeadersInit);
+      captured = new Headers(init?.headers);
       return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
     };
 
@@ -152,7 +152,7 @@ describe('dispatchChorus', () => {
   it('strips hop-by-hop headers per RFC 7230', async () => {
     let captured: Headers | undefined;
     const fetchImpl: typeof fetch = async (_url, init) => {
-      captured = new Headers(init?.headers as HeadersInit);
+      captured = new Headers(init?.headers);
       return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
     };
 

--- a/test/chorus.test.ts
+++ b/test/chorus.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import { dispatchChorus } from '../src/escalation/chorus.js';
+import { DEFAULT_CHORUS_TIMEOUT_MS, type EscalationConfig } from '../src/types.js';
+
+function makeConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
+  return {
+    mode: 'chorus',
+    ladder: [],
+    maxDepth: 1,
+    ...overrides,
+  };
+}
+
+function makeInput(
+  overrides: Partial<Parameters<typeof dispatchChorus>[1]> = {},
+): Parameters<typeof dispatchChorus>[1] {
+  return {
+    bodyBytes: '{"messages":[{"role":"user","content":"hi"}]}',
+    clientHeaders: new Headers({ 'content-type': 'application/json' }),
+    contextHeaders: {},
+    ...overrides,
+  };
+}
+
+describe('dispatchChorus', () => {
+  it('returns endpoint_not_set when chorusEndpoint is undefined', async () => {
+    const result = await dispatchChorus(makeConfig(), makeInput());
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('endpoint_not_set');
+    }
+  });
+
+  it('returns endpoint_not_set when chorusEndpoint is an empty string', async () => {
+    const result = await dispatchChorus(makeConfig({ chorusEndpoint: '' }), makeInput());
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('endpoint_not_set');
+    }
+  });
+
+  it('returns ok when the endpoint responds 200', async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response('{"id":"1"}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const result = await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/v1/chat/completions' }),
+      makeInput({ fetchImpl }),
+    );
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.response.status).toBe(200);
+    }
+  });
+
+  it('returns non_ok_status when the endpoint responds 500', async () => {
+    const fetchImpl: typeof fetch = async () => new Response('boom', { status: 500 });
+    const result = await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/v1/chat/completions' }),
+      makeInput({ fetchImpl }),
+    );
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('non_ok_status');
+      expect(result.detail).toContain('500');
+    }
+  });
+
+  it('classifies network/DNS errors as unreachable', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new TypeError('fetch failed: getaddrinfo ENOTFOUND example.invalid');
+    };
+    const result = await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.invalid/' }),
+      makeInput({ fetchImpl }),
+    );
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('unreachable');
+      expect(result.detail).toContain('ENOTFOUND');
+    }
+  });
+
+  it('classifies AbortError as timeout', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+    const result = await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/', chorusTimeoutMs: 10 }),
+      makeInput({ fetchImpl }),
+    );
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('timeout');
+      expect(result.detail).toContain('10ms');
+    }
+  });
+
+  it('uses DEFAULT_CHORUS_TIMEOUT_MS when chorusTimeoutMs is unset', async () => {
+    // We cannot easily assert the actual setTimeout delay without
+    // time-travel, so verify indirectly: the detail for a timeout
+    // error reports the default value when no override is set.
+    const fetchImpl: typeof fetch = async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+    const result = await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/' }),
+      makeInput({ fetchImpl }),
+    );
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.reason).toBe('timeout');
+      expect(result.detail).toContain(String(DEFAULT_CHORUS_TIMEOUT_MS));
+    }
+  });
+
+  it('forwards context headers on top of client headers', async () => {
+    let captured: Headers | undefined;
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      captured = new Headers(init?.headers as HeadersInit);
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+
+    await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/' }),
+      makeInput({
+        clientHeaders: new Headers({
+          'content-type': 'application/json',
+          authorization: 'Bearer xyz',
+        }),
+        contextHeaders: {
+          'x-turbocharger-reason': 'hard_signals',
+          'x-turbocharger-aggregate': '0.712',
+        },
+        fetchImpl,
+      }),
+    );
+
+    expect(captured?.get('authorization')).toBe('Bearer xyz');
+    expect(captured?.get('x-turbocharger-reason')).toBe('hard_signals');
+    expect(captured?.get('x-turbocharger-aggregate')).toBe('0.712');
+  });
+
+  it('strips hop-by-hop headers per RFC 7230', async () => {
+    let captured: Headers | undefined;
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      captured = new Headers(init?.headers as HeadersInit);
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+
+    await dispatchChorus(
+      makeConfig({ chorusEndpoint: 'http://example.test/' }),
+      makeInput({
+        clientHeaders: new Headers({
+          'content-type': 'application/json',
+          connection: 'keep-alive',
+          'transfer-encoding': 'chunked',
+          'keep-alive': 'timeout=5',
+        }),
+        fetchImpl,
+      }),
+    );
+
+    expect(captured?.get('connection')).toBeNull();
+    expect(captured?.get('transfer-encoding')).toBeNull();
+    expect(captured?.get('keep-alive')).toBeNull();
+    expect(captured?.get('content-type')).toBe('application/json');
+  });
+});

--- a/test/pipeline-escalation.test.ts
+++ b/test/pipeline-escalation.test.ts
@@ -600,3 +600,300 @@ describe('pipeline escalation (max)', () => {
     expect(mock.bodies()).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Chorus-mode (issue #8)
+// ---------------------------------------------------------------------------
+
+describe('pipeline escalation (chorus)', () => {
+  let downstream: MockDownstream;
+  let chorus: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    downstream = await startMockDownstream();
+    chorus = await startMockDownstream();
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await downstream.close();
+    await chorus.close();
+  });
+
+  it('dispatches to the chorus endpoint when the first response refuses', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: [],
+          chorusEndpoint: `${chorus.baseUrl}/chat/completions`,
+          maxDepth: 1,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help with that."));
+    });
+    chorus.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer from the chorus with concrete details.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('1');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBe('chorus');
+
+    const finalBody = await res.text();
+    expect(finalBody).toContain('clear, complete, helpful answer from the chorus');
+
+    expect(downstream.bodies()).toHaveLength(1);
+    expect(chorus.bodies()).toHaveLength(1);
+  });
+
+  it('reports chorus_endpoint_not_set when chorusEndpoint is unset', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: [],
+          maxDepth: 1,
+          // chorusEndpoint intentionally omitted
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('chorus_endpoint_not_set');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-path')).toBeNull();
+    expect(downstream.bodies()).toHaveLength(1);
+    expect(chorus.bodies()).toHaveLength(0);
+  });
+
+  it('reports chorus_non_ok_status when the endpoint responds 500', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: [],
+          chorusEndpoint: `${chorus.baseUrl}/chat/completions`,
+          maxDepth: 1,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+    chorus.setHandler((_req, res, _body) => {
+      res.writeHead(500);
+      res.end('chorus crashed');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('chorus_non_ok_status');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(downstream.bodies()).toHaveLength(1);
+    expect(chorus.bodies()).toHaveLength(1);
+  });
+
+  it('does not dispatch to chorus when the first response passes', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: [],
+          chorusEndpoint: `${chorus.baseUrl}/chat/completions`,
+          maxDepth: 1,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+    chorus.setHandler((_req, res, _body) => {
+      res.writeHead(500);
+      res.end('should not be called');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Explain briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+    expect(downstream.bodies()).toHaveLength(1);
+    expect(chorus.bodies()).toHaveLength(0);
+  });
+
+  it('respects maxDepth=0 and does not dispatch even when endpoint is set', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: [],
+          chorusEndpoint: `${chorus.baseUrl}/chat/completions`,
+          maxDepth: 0,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+    chorus.setHandler((_req, res, _body) => {
+      res.writeHead(500);
+      res.end('should not be called');
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
+    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
+    expect(chorus.bodies()).toHaveLength(0);
+  });
+
+  it('forwards X-Turbocharger-* context headers to the chorus endpoint', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: downstream.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({
+          mode: 'chorus',
+          ladder: ['weak-model', 'mid-model'],
+          chorusEndpoint: `${chorus.baseUrl}/chat/completions`,
+          maxDepth: 1,
+        }),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    let capturedHeaders: Record<string, string | string[] | undefined> | undefined;
+
+    downstream.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+    chorus.setHandler((req, res, _body) => {
+      capturedHeaders = req.headers;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody('chorus answer'));
+    });
+
+    await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    expect(capturedHeaders).toBeDefined();
+    expect(capturedHeaders?.['x-turbocharger-reason']).toBe('hard_signals');
+    expect(capturedHeaders?.['x-turbocharger-ladder']).toBe('weak-model,mid-model');
+  });
+});

--- a/test/pipeline-escalation.test.ts
+++ b/test/pipeline-escalation.test.ts
@@ -305,45 +305,6 @@ describe('pipeline escalation (ladder)', () => {
     expect(mock.bodies()).toHaveLength(1);
   });
 
-  it('does not escalate when mode is chorus (not yet implemented in issue 6 or 7)', async () => {
-    await sidecar.close();
-    logs = [];
-    sidecar = startServer(
-      { port: 0, downstreamBaseUrl: mock.baseUrl },
-      {
-        logger: (entry) => {
-          logs.push(entry as DecisionLogEntry);
-        },
-        orchestratorConfig: makeOrchestratorConfig(),
-        escalationConfig: makeEscalationConfig({
-          mode: 'chorus',
-          chorusEndpoint: 'http://example.test/unused',
-        }),
-      },
-    );
-    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
-
-    mock.setHandler((_req, res, _body) => {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
-    });
-
-    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: 'weak-model',
-        messages: [{ role: 'user', content: 'help' }],
-      }),
-    });
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('x-turbocharger-decision')).toBe('escalate');
-    expect(res.headers.get('x-turbocharger-escalation-depth')).toBe('0');
-    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('not_attempted');
-    expect(mock.bodies()).toHaveLength(1);
-  });
-
   it('maxDepth: 0 disables escalation entirely', async () => {
     await sidecar.close();
     logs = [];


### PR DESCRIPTION
Closes issue 8.

Adds the third escalation mode: chorus dispatch. Exactly what the
brief §5 calls for at the interface level — the sidecar POSTs the
client's original request to a configured external endpoint and
forwards the endpoint's response to the client as-is. The endpoint
itself (parallel multi-model dispatch, consensus synthesis, minority
reports) lives in a separate project (openclaw-chorus) that is not
in scope here.

## Commits

Five.

- **feat** — dispatchChorus pure function with four-way error
  classification, chorus branch in the pipeline BEFORE the
  ladder/max loop (structurally separate because chorus uses a
  different endpoint), four new stoppedReason values, 90s default
  timeout.
- **test** — 9 unit tests for dispatchChorus + 6 pipeline
  integration tests using a second MockDownstream as the chorus
  server.
- **docs** — ADR-0020 documents the OpenAI-compatible protocol,
  hard-fail policy (revising brief §5), and timeout rationale.
- **fix(test)** — drop HeadersInit cast that required DOM lib.
  Caught by pnpm check on first run.
- **fix(test)** — remove the stale "mode is chorus (not yet
  implemented)" placeholder test from Issue #7; chorus is now
  operational and the test's premise no longer holds. The new
  chorus describe block already covers the unreachable-endpoint
  case.

## Verification

`pnpm check` green locally: 136 passed / 3 todo.

## Not in this PR

- The chorus logic itself (parallel dispatch, synthesis) — lives
  in openclaw-chorus.
- Fallback to ladder/max on chorus failure — deliberately not
  implemented per ADR-0020. Users can compose a fallback at the
  config layer once issue #11 introduces the Zod-validated config.
- Body-level transparency for chorus attempts (issues 9, 10).

## README update

The README still says "7 of 15 merged" from PR #12. Not bumped in
this PR because the README wasn't in my baseline snapshot. Can be
caught up as a small follow-up PR or with issue #9.