### PR TITLE
feat: transparency banner for surfacing escalation events (Issue #9, ADR-0022)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1070,3 +1070,140 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   downstream — chorus is not bound by that because it's no longer
   an escalation strategy); Issue #8 (where chorus was originally
   scaffolded).
+
+## ADR-0022: Transparency banner is opt-in, body-mutating, locale-aware
+
+- **Date:** 2026-04-23
+- **Status:** accepted, implements brief §7
+- **Decision:** The transparency layer (Issue #9) ships with one
+  active mode — `banner` — and one default — `silent`. The default
+  is silent: a sidecar started without an explicit
+  `transparencyConfig` will not modify any response body, even when
+  escalation happens. Operators who want end users to see a banner
+  must opt in by setting `transparencyConfig: { mode: 'banner' }`
+  on AppDeps. When opted in, every escalation/skipped-with-reason
+  decision in single-mode requests produces a single-line banner
+  prepended to the assistant content with the marker
+  `[turbocharger]` and a blank line separator. Banners are
+  locale-aware (English default, German for `de*` locales) and
+  deliberately vague in tone ("looked incomplete", not "was
+  wrong"). Pass decisions never produce a banner. Chorus-mode
+  responses are out of scope and never touched.
+- **Rationale:** Three decisions are bundled into one ADR because
+  they share the same underlying principle: the transparency layer
+  trades response-body invasiveness for end-user visibility, and
+  every aspect of that trade-off needs to default to caution.
+  - _Silent default._ The brief §7 says "banner-as-default" for
+    the user-facing vision, but that's the default a deployment
+    should *aim for*, not the default a constructor should pick
+    for a misconfigured deployment. A sidecar starting without
+    explicit config landing on a Hono app and silently mutating
+    every response with `[turbocharger]` text would surprise
+    operators in ways the project's "no silent fallbacks" stance
+    does not allow. Silent-as-technical-default lets the brief's
+    user-facing default live in `examples/standalone-config.example.yaml`
+    and the README, where operators see and accept it
+    consciously, rather than as a hidden constructor behaviour.
+    Because of this asymmetry between technical default and
+    recommended default, the README, CONFIGURATION.md, and the
+    JSDoc on `TransparencyConfig` all explicitly tell operators
+    they MUST set `mode: 'banner'` to surface escalation events
+    — silent is "do nothing visible", not "the recommended
+    user experience".
+  - _Body-mutating, not header-only._ Headers (`x-turbocharger-*`)
+    already exist for the same information and have done since
+    Issue #5. The brief's transparency goal is end-user-visible
+    output, not API metadata, and end users do not see HTTP
+    headers — they see assistant message content. Banner injection
+    therefore mutates `choices[0].message.content`. This is
+    invasive but it is the only way to actually meet the brief's
+    goal. The marker `[turbocharger]` plus blank-line separator
+    keeps the injection unambiguously machine-strippable for
+    clients that prefer the headers-only view.
+  - _Tone is vague, not technical._ "The first answer looked
+    incomplete" instead of "A refusal pattern was detected". The
+    project's "do not overclaim" principle (brief §14, item 7)
+    rules out language that asserts the original answer was
+    objectively wrong; the adequacy critic detected a flag, not
+    a proven inadequacy. Vague language also avoids leaking
+    implementation details about specific signal categories,
+    which is good for forward-compatibility (Issue #11+ may add,
+    rename, or remove categories) and good for the user
+    (knowing the category is rarely what they need; knowing
+    "the system noticed something off and tried again" is).
+  - _Locale-aware (en + de only)._ Two locales is enough for v0.1
+    given the project's EU/DACH-friendly positioning. The
+    BCP-47 prefix-match (`de-AT` → `de`) keeps the resolver
+    simple. Other locales fall through to English. Issue #11's
+    config schema can later allow operators to add their own
+    locale tables without changing the banner module's API.
+- **Alternatives considered:**
+  - _Banner-as-default, opt-out via silent._ Considered: align
+    technical default with the brief's user-facing recommendation.
+    Rejected because the failure mode of "default mutates response
+    bodies" is much worse than "default is silent": a
+    misconfigured client could end up with `[turbocharger]`
+    prefixes in stored conversation logs, and the operator might
+    not notice for days. Silent-as-default fails closed.
+  - _Header-only transparency, no body mutation._ Considered:
+    keep transparency entirely in `x-turbocharger-*` headers,
+    skip body mutation. Rejected because the brief's goal is
+    end-user visibility, and end users do not read response
+    headers. Header-only transparency would meet the API
+    requirements but not the user-facing requirement.
+  - _Per-decision verbosity (banner vs card vs silent toggleable
+    per request)._ Considered: let clients pick the mode via
+    `X-Turbocharger-Transparency` header. Rejected for v0.1: it
+    conflates two issues. Issue #9 is about the banner; Issue
+    #10 is about the card; Issue #12 is about per-request
+    overrides. Bundling them all into one PR would make each
+    harder to review.
+  - _Render banner at the END of the content instead of the
+    beginning._ Considered: less visually invasive when reading
+    streaming output, more readable in chat UIs that auto-scroll
+    to bottom. Rejected because (a) streaming is out of scope
+    per ADR-0013 — this layer never sees streamed responses,
+    (b) appending after content makes it easy for the user to
+    miss the banner if the response is long, and (c) the
+    pipeline already has the response body buffered, so prefix
+    placement is not harder than suffix placement.
+- **Mechanical scope of Issue #9:**
+  - New `TransparencyConfig` type with single field `mode:
+    'banner' | 'silent'`. Issue #10 will add `'card'`.
+  - `src/transparency/banner.ts` becomes a real module
+    (replacing the Issue #1 stub) exporting `formatBanner`,
+    `formatBannerPrefix`, and `resolveBannerLocale`.
+  - `PipelineInput` gains optional `transparencyConfig`.
+  - Pipeline calls `formatBannerPrefix` after the escalation
+    loop, before constructing the final Response. Banner
+    injection mutates a parsed copy of `currentBodyText` and
+    re-stringifies it; if parsing fails or the body shape is
+    unexpected, the original body is preserved (defensive
+    fallback so a misconfiguration cannot corrupt responses).
+  - `AppDeps` gains optional `transparencyConfig` which the
+    server passes through to the pipeline.
+  - `DecisionLogEntry` gains optional `transparency_mode` so
+    log aggregators can correlate body-mutation behaviour
+    without re-parsing response bodies.
+  - Two test files: `test/banner.test.ts` (24 unit tests for
+    `formatBanner` + `resolveBannerLocale`) and
+    `test/pipeline-banner.test.ts` (6 integration tests
+    covering banner-on-escalate, no-banner-on-pass,
+    silent-mode, default-silent, not_attempted, and German
+    locale).
+- **Consequences for downstream issues:**
+  - Issue #10 (transparency: card) extends `TransparencyConfig.mode`
+    to a third literal `'card'` and adds card-rendering to the
+    same injection path.
+  - Issue #11 (config:schema) needs to validate
+    `TransparencyConfig` and to expose `mode: 'banner'` as the
+    *recommended* default in `examples/standalone-config.example.yaml`.
+  - Issue #12 (per-request header override) gains
+    `X-Turbocharger-Transparency: banner|silent|card` as an
+    optional override on top of the configured default.
+  - The README's positioning section can now show concrete
+    banner output as a screenshot or code block.
+- **Related:** ADR-0007 (transparency-as-design-principle),
+  ADR-0013 (no transparency for streaming responses),
+  ADR-0021 (chorus-mode is out of transparency layer scope),
+  brief §7 and §14.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1095,7 +1095,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   every aspect of that trade-off needs to default to caution.
   - _Silent default._ The brief §7 says "banner-as-default" for
     the user-facing vision, but that's the default a deployment
-    should *aim for*, not the default a constructor should pick
+    should _aim for_, not the default a constructor should pick
     for a misconfigured deployment. A sidecar starting without
     explicit config landing on a Hono app and silently mutating
     every response with `[turbocharger]` text would surprise
@@ -1169,7 +1169,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     placement is not harder than suffix placement.
 - **Mechanical scope of Issue #9:**
   - New `TransparencyConfig` type with single field `mode:
-    'banner' | 'silent'`. Issue #10 will add `'card'`.
+'banner' | 'silent'`. Issue #10 will add `'card'`.
   - `src/transparency/banner.ts` becomes a real module
     (replacing the Issue #1 stub) exporting `formatBanner`,
     `formatBannerPrefix`, and `resolveBannerLocale`.
@@ -1197,7 +1197,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     same injection path.
   - Issue #11 (config:schema) needs to validate
     `TransparencyConfig` and to expose `mode: 'banner'` as the
-    *recommended* default in `examples/standalone-config.example.yaml`.
+    _recommended_ default in `examples/standalone-config.example.yaml`.
   - Issue #12 (per-request header override) gains
     `X-Turbocharger-Transparency: banner|silent|card` as an
     optional override on top of the configured default.

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -40,6 +40,7 @@ import { nextLadderStep } from './escalation/ladder.js';
 import { maxStep } from './escalation/max.js';
 import { dispatchChorus } from './chorus/dispatch.js';
 import { forwardChatCompletion } from './proxy.js';
+import { formatBannerPrefix } from './transparency/banner.js';
 import type {
   AnswerMode,
   ChorusConfig,
@@ -49,6 +50,7 @@ import type {
   OrchestratorConfig,
   OrchestratorDecision,
   ProxyTarget,
+  TransparencyConfig,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -278,6 +280,16 @@ export interface PipelineInput {
   readonly answerMode: AnswerMode;
   readonly chorusConfig?: ChorusConfig;
   readonly escalationConfig?: EscalationConfig;
+  /**
+   * Optional transparency configuration. When `mode: 'banner'`, the
+   * pipeline prepends a localized banner to the assistant content for
+   * single-mode requests where the orchestrator decided escalate or
+   * skipped-with-reason. When absent or `mode: 'silent'`, the
+   * response body is forwarded unchanged. Per Issue #9 and ADR-0022,
+   * chorus-mode responses are never modified by the transparency
+   * layer regardless of this setting.
+   */
+  readonly transparencyConfig?: TransparencyConfig;
 }
 
 /**
@@ -521,6 +533,19 @@ async function runSinglePipeline(input: PipelineInput): Promise<SinglePipelineRe
 
   const trace: EscalationTrace = { path, stoppedReason, depth };
 
+  // Transparency banner injection (Issue #9). Only runs when:
+  //   - transparencyConfig.mode === 'banner' (default is silent),
+  //   - the response body is JSON (we already established this above),
+  //   - formatBannerPrefix returns non-null (i.e. not a pass decision).
+  // The original currentBodyText is replaced with one whose
+  // choices[0].message.content has the banner prepended.
+  if (input.transparencyConfig?.mode === 'banner') {
+    const banner = formatBannerPrefix(currentDecision, trace, parsed.locale);
+    if (banner !== null) {
+      currentBodyText = injectBannerIntoBody(currentBodyText, banner);
+    }
+  }
+
   const reconstituted = new Response(currentBodyText, {
     status: currentResponse.status,
     statusText: currentResponse.statusText,
@@ -552,4 +577,46 @@ function buildOrchestratorInput(
     ...(assistant.finishReason !== undefined ? { finishReason: assistant.finishReason } : {}),
     ...(parsed.locale !== undefined ? { locale: parsed.locale } : {}),
   };
+}
+
+/**
+ * Prepend the transparency banner to `choices[0].message.content` of
+ * an OpenAI-compatible chat completion JSON body. Returns the modified
+ * body as a string.
+ *
+ * If the body is malformed JSON or the choices array is missing, the
+ * banner cannot be safely injected and the original body is returned
+ * unchanged. The pipeline has already established earlier that the
+ * downstream content-type is `application/json` and the orchestrator
+ * could parse the response, so a malformed body here would be unusual,
+ * but the defensive fallback keeps a transparency misconfiguration from
+ * corrupting the client's response.
+ */
+function injectBannerIntoBody(bodyText: string, bannerPrefix: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return bodyText;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return bodyText;
+  const obj = parsed as Record<string, unknown>;
+  const choices = obj['choices'];
+  if (!Array.isArray(choices) || choices.length === 0) return bodyText;
+  const firstChoice = choices[0];
+  if (typeof firstChoice !== 'object' || firstChoice === null) return bodyText;
+  const choiceObj = firstChoice as Record<string, unknown>;
+  const message = choiceObj['message'];
+  if (typeof message !== 'object' || message === null) return bodyText;
+  const messageObj = message as Record<string, unknown>;
+  const content = messageObj['content'];
+  // Only string content is supported; structured array content is left
+  // alone because banner placement inside an array of content parts is
+  // ambiguous and not in scope for v0.1.
+  if (typeof content !== 'string') return bodyText;
+  const newMessage = { ...messageObj, content: bannerPrefix + content };
+  const newChoice = { ...choiceObj, message: newMessage };
+  const newChoices = [newChoice, ...choices.slice(1)];
+  const newBody = { ...obj, choices: newChoices };
+  return JSON.stringify(newBody);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import type {
   ProxyTarget,
   RequestLogEntry,
   RequestLogger,
+  TransparencyConfig,
 } from './types.js';
 
 export interface AppDeps {
@@ -64,6 +65,19 @@ export interface AppDeps {
    * (issue #12). When absent, `single` is assumed.
    */
   readonly defaultAnswerMode?: AnswerMode;
+  /**
+   * Optional transparency configuration. When `mode: 'banner'`, the
+   * pipeline prepends a localized banner to the assistant content for
+   * single-mode requests where the orchestrator decided escalate or
+   * skipped-with-reason. When absent or `mode: 'silent'`, the
+   * response body is forwarded unchanged.
+   *
+   * IMPORTANT: the technical default is `silent`. To make escalation
+   * events visible to end users, operators MUST opt in by setting
+   * `mode: 'banner'`. See {@link TransparencyConfig} for the full
+   * rationale.
+   */
+  readonly transparencyConfig?: TransparencyConfig;
 }
 
 /**
@@ -81,6 +95,7 @@ export interface DecisionLogEntry extends RequestLogEntry {
   readonly escalation_path?: readonly string[];
   readonly chorus_outcome?: ChorusTrace['outcome'];
   readonly chorus_detail?: string;
+  readonly transparency_mode?: TransparencyConfig['mode'];
 }
 
 const defaultLogger: RequestLogger = (entry) => {
@@ -162,6 +177,9 @@ export function createApp(deps: AppDeps): Hono {
           ...(deps.escalationConfig !== undefined
             ? { escalationConfig: deps.escalationConfig }
             : {}),
+          ...(deps.transparencyConfig !== undefined
+            ? { transparencyConfig: deps.transparencyConfig }
+            : {}),
         });
         status = result.response.status;
         if (result.mode === 'single') {
@@ -209,6 +227,9 @@ export function createApp(deps: AppDeps): Hono {
         ...(escalationPath !== undefined ? { escalation_path: escalationPath } : {}),
         ...(chorusOutcome !== undefined ? { chorus_outcome: chorusOutcome } : {}),
         ...(chorusDetail !== undefined ? { chorus_detail: chorusDetail } : {}),
+        ...(deps.transparencyConfig !== undefined
+          ? { transparency_mode: deps.transparencyConfig.mode }
+          : {}),
       };
       log(entry);
     }
@@ -240,6 +261,9 @@ export function startServer(
     ...(deps?.escalationConfig !== undefined ? { escalationConfig: deps.escalationConfig } : {}),
     ...(deps?.chorusConfig !== undefined ? { chorusConfig: deps.chorusConfig } : {}),
     ...(deps?.defaultAnswerMode !== undefined ? { defaultAnswerMode: deps.defaultAnswerMode } : {}),
+    ...(deps?.transparencyConfig !== undefined
+      ? { transparencyConfig: deps.transparencyConfig }
+      : {}),
   });
 
   const server = serve({

--- a/src/transparency/banner.ts
+++ b/src/transparency/banner.ts
@@ -158,8 +158,7 @@ const SKIPPED_TEXT: Record<
 > = {
   en: {
     non_ok_status: 'The downstream model returned an error response.',
-    non_json_content_type:
-      'The downstream model returned a response that could not be evaluated.',
+    non_json_content_type: 'The downstream model returned a response that could not be evaluated.',
   },
   de: {
     non_ok_status: 'Das Backend-Modell hat eine Fehlerantwort zurückgegeben.',

--- a/src/transparency/banner.ts
+++ b/src/transparency/banner.ts
@@ -69,9 +69,15 @@ export function formatBanner(
   trace: EscalationTrace,
   locale: string | undefined,
 ): string | null {
-  if (decision.kind === 'pass') return null;
-
   const lang = resolveBannerLocale(locale);
+
+  // Suppress the banner only when the very first response passed —
+  // i.e. the orchestrator said pass AND no escalation ever ran. If a
+  // re-query produced a passing answer (decision: pass, depth > 0),
+  // the banner IS what the user should see: the visible answer comes
+  // from a different model than the client requested, and that's
+  // exactly the transparency goal.
+  if (decision.kind === 'pass' && trace.depth === 0) return null;
 
   if (decision.kind === 'skipped') {
     const text = SKIPPED_TEXT[lang][decision.reason];
@@ -79,7 +85,11 @@ export function formatBanner(
     return `${BANNER_MARKER} ${text}`;
   }
 
-  // decision.kind === 'escalate'
+  // Either decision.kind === 'escalate' (the loop ended without a
+  // passing answer) or decision.kind === 'pass' with depth > 0 (a
+  // re-query produced a passing answer). Both cases share the same
+  // narrative, parameterized by trace.stoppedReason — the i18n table
+  // maps stoppedReason to the user-facing text.
   const text = ESCALATE_TEXT[lang][trace.stoppedReason];
   return `${BANNER_MARKER} ${text}`;
 }

--- a/src/transparency/banner.ts
+++ b/src/transparency/banner.ts
@@ -1,5 +1,159 @@
-// TODO(issue #9): Banner mode (default).
-// Prepends a short single-line annotation when escalation happened, e.g.:
-//   [turbocharger] Escalated haiku → sonnet. Reason: refusal pattern detected.
+// Transparency banner (Issue #9).
+//
+// Produces a short, locale-aware text annotation that the pipeline
+// prepends to the response content when the orchestrator decided that
+// escalation was warranted. The goal is to make adequacy decisions
+// visible to the end user without overwhelming them — when a request
+// passed adequacy on the first try, no banner is emitted.
+//
+// Per the brief (§7) the banner is the default-recommended transparency
+// mode for v0.1, but the technical default for {@link TransparencyConfig.mode}
+// is `silent`: a sidecar deployed without explicit transparency config
+// must not start mutating response bodies. Operators opt in by setting
+// `mode: 'banner'` on their AppDeps. Once opted in, every escalation
+// decision in single-mode requests produces a banner; chorus-mode
+// responses are untouched per ADR-0021.
+//
+// The banner format is a single-line marker plus the localized text,
+// followed by a blank line, then the original content:
+//
+//   [turbocharger] <localized message>
+//
+//   <original assistant content>
+//
+// The `[turbocharger]` marker is unambiguous and machine-parseable —
+// downstream clients that want to strip the banner can match
+// `/^\[turbocharger\] [^\n]+\n\n/`.
+//
+// Scope (v0.1, Issue #9):
+//   - Banner only. The `card` mode arrives in Issue #10 with a
+//     structured JSON-in-content surface.
+//   - Two locales: `en` (default fallback) and `de` (covers de-DE,
+//     de-AT, de-CH via prefix match). Other locales fall through to
+//     `en`.
+//   - No banner for `decision: pass`. The user only sees a banner
+//     when something *interesting* happened — escalation, skip with
+//     reason, or a hard configuration stop.
+//   - No banner for streaming responses (ADR-0013): the pipeline
+//     skips the orchestrator entirely there, so this module never
+//     gets called for those.
+//   - No banner for chorus-mode responses (ADR-0021): chorus is its
+//     own paradigm and its outcome surface is the chorus headers.
 
-export {};
+import type { EscalationTrace, OrchestratorDecision } from '../types.js';
+
+export type BannerLocale = 'en' | 'de';
+
+const BANNER_MARKER = '[turbocharger]';
+
+/**
+ * Resolve a BCP-47 locale tag to one of the supported banner locales.
+ * Prefix-matches `de*` → `de`; everything else falls through to `en`.
+ */
+export function resolveBannerLocale(locale: string | undefined): BannerLocale {
+  if (locale === undefined || locale.length === 0) return 'en';
+  const lower = locale.toLowerCase();
+  if (lower === 'de' || lower.startsWith('de-') || lower.startsWith('de_')) return 'de';
+  return 'en';
+}
+
+/**
+ * Produce the banner text (without trailing blank line) for a given
+ * decision and trace, or `null` if no banner should be emitted.
+ *
+ * Returns `null` for `kind: 'pass'` per the design decision that
+ * users should only see a banner when escalation/skip happened.
+ */
+export function formatBanner(
+  decision: OrchestratorDecision,
+  trace: EscalationTrace,
+  locale: string | undefined,
+): string | null {
+  if (decision.kind === 'pass') return null;
+
+  const lang = resolveBannerLocale(locale);
+
+  if (decision.kind === 'skipped') {
+    const text = SKIPPED_TEXT[lang][decision.reason];
+    if (text === undefined) return null;
+    return `${BANNER_MARKER} ${text}`;
+  }
+
+  // decision.kind === 'escalate'
+  const text = ESCALATE_TEXT[lang][trace.stoppedReason];
+  return `${BANNER_MARKER} ${text}`;
+}
+
+/**
+ * Convenience for the pipeline: returns the banner text plus the
+ * trailing blank line, ready to be prepended to assistant content.
+ * Returns `null` when no banner should be emitted.
+ */
+export function formatBannerPrefix(
+  decision: OrchestratorDecision,
+  trace: EscalationTrace,
+  locale: string | undefined,
+): string | null {
+  const banner = formatBanner(decision, trace, locale);
+  if (banner === null) return null;
+  return `${banner}\n\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Text tables
+// ---------------------------------------------------------------------------
+
+// Tone: deliberately vague. Per the project principle "do not overclaim",
+// the banner says "looked incomplete" rather than "was wrong" — we report
+// what the adequacy critic flagged, not a definitive judgement of the
+// answer's correctness.
+
+const ESCALATE_TEXT: Record<BannerLocale, Record<EscalationTrace['stoppedReason'], string>> = {
+  en: {
+    passed:
+      'A stronger model was used because the first answer looked incomplete. The answer below is from the stronger model.',
+    max_depth_reached:
+      'The first answer looked incomplete and a stronger model was tried, but its answer was also flagged. The answer below is the last attempt.',
+    ladder_exhausted:
+      'The first answer looked incomplete and the strongest available model was tried, but its answer was also flagged. The answer below is from that model.',
+    model_not_on_ladder:
+      'The first answer looked incomplete, but no stronger model is configured for this request. The answer below is the original.',
+    max_model_not_set:
+      'The first answer looked incomplete, but max-mode escalation has no target model configured. The answer below is the original.',
+    not_attempted:
+      'The first answer looked incomplete, but escalation is disabled for this request. The answer below is the original.',
+  },
+  de: {
+    passed:
+      'Ein stärkeres Modell wurde verwendet, weil die erste Antwort unvollständig wirkte. Die Antwort unten stammt vom stärkeren Modell.',
+    max_depth_reached:
+      'Die erste Antwort wirkte unvollständig; ein stärkeres Modell wurde versucht, aber auch dessen Antwort wurde als unzureichend markiert. Die Antwort unten ist der letzte Versuch.',
+    ladder_exhausted:
+      'Die erste Antwort wirkte unvollständig; das stärkste verfügbare Modell wurde versucht, aber auch dessen Antwort wurde markiert. Die Antwort unten stammt von diesem Modell.',
+    model_not_on_ladder:
+      'Die erste Antwort wirkte unvollständig, aber für diese Anfrage ist kein stärkeres Modell konfiguriert. Die Antwort unten ist die ursprüngliche.',
+    max_model_not_set:
+      'Die erste Antwort wirkte unvollständig, aber für Max-Mode ist kein Zielmodell konfiguriert. Die Antwort unten ist die ursprüngliche.',
+    not_attempted:
+      'Die erste Antwort wirkte unvollständig, aber Eskalation ist für diese Anfrage deaktiviert. Die Antwort unten ist die ursprüngliche.',
+  },
+};
+
+// Streaming is intentionally absent: streaming responses skip the
+// orchestrator entirely (ADR-0013) and this module is never called
+// for them. We list it as undefined-skipping to make that explicit.
+const SKIPPED_TEXT: Record<
+  BannerLocale,
+  Partial<Record<NonNullable<Extract<OrchestratorDecision, { kind: 'skipped' }>['reason']>, string>>
+> = {
+  en: {
+    non_ok_status: 'The downstream model returned an error response.',
+    non_json_content_type:
+      'The downstream model returned a response that could not be evaluated.',
+  },
+  de: {
+    non_ok_status: 'Das Backend-Modell hat eine Fehlerantwort zurückgegeben.',
+    non_json_content_type:
+      'Das Backend-Modell hat eine Antwort zurückgegeben, die nicht ausgewertet werden konnte.',
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -485,3 +485,35 @@ export interface ChorusTrace {
   /** Human-readable detail for error outcomes. */
   readonly detail?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Transparency layer (Issue #9)
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the transparency layer that surfaces escalation
+ * decisions to the end user via the response body.
+ *
+ * - `silent` (default): no body modification. Decisions are still
+ *   reported via response headers (`x-turbocharger-*`) and the
+ *   per-request log line, but the assistant content is unchanged.
+ * - `banner`: a single-line localized message marked with
+ *   `[turbocharger]` is prepended to the assistant's content,
+ *   followed by a blank line, when an escalation decision was
+ *   made (escalate or skipped-with-reason). No banner is emitted
+ *   for `pass` decisions.
+ *
+ * IMPORTANT: the technical default is `silent`. A sidecar that
+ * starts without an explicit `transparencyConfig` will never mutate
+ * response bodies. To make escalation events visible to end users,
+ * operators MUST opt in by setting `mode: 'banner'`. This is a
+ * deliberate choice: response-body mutation is invasive and should
+ * only happen when the operator has consciously chosen it.
+ *
+ * Issue #10 will add `mode: 'card'` for a structured JSON-in-content
+ * surface as a third option. Chorus-mode responses are out of scope
+ * for the transparency layer per ADR-0021.
+ */
+export interface TransparencyConfig {
+  readonly mode: 'banner' | 'silent';
+}

--- a/test/banner.test.ts
+++ b/test/banner.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatBanner,
+  formatBannerPrefix,
+  resolveBannerLocale,
+  type BannerLocale,
+} from '../src/transparency/banner.js';
+import type { EscalationTrace, OrchestratorDecision } from '../src/types.js';
+
+function trace(
+  stoppedReason: EscalationTrace['stoppedReason'],
+  depth = 0,
+  path: readonly string[] = [],
+): EscalationTrace {
+  return { path, stoppedReason, depth };
+}
+
+const PASS_DECISION: OrchestratorDecision = {
+  kind: 'pass',
+  signals: [],
+  aggregate: 0,
+};
+
+const ESCALATE_DECISION: OrchestratorDecision = {
+  kind: 'escalate',
+  reason: 'hard_signals',
+  signals: [],
+  aggregate: 0.8,
+};
+
+describe('resolveBannerLocale', () => {
+  it.each<[string | undefined, BannerLocale]>([
+    [undefined, 'en'],
+    ['', 'en'],
+    ['en', 'en'],
+    ['en-US', 'en'],
+    ['fr', 'en'],
+    ['fr-FR', 'en'],
+    ['de', 'de'],
+    ['de-DE', 'de'],
+    ['de-AT', 'de'],
+    ['de-CH', 'de'],
+    ['DE-DE', 'de'],
+    ['de_DE', 'de'],
+    ['deutsch', 'en'],
+  ])('locale %s resolves to %s', (input, expected) => {
+    expect(resolveBannerLocale(input)).toBe(expected);
+  });
+});
+
+describe('formatBanner — pass decisions return null', () => {
+  it.each<string | undefined>(['en', 'de', undefined])(
+    'returns null for pass in locale %s',
+    (locale) => {
+      expect(formatBanner(PASS_DECISION, trace('passed'), locale)).toBeNull();
+      expect(formatBannerPrefix(PASS_DECISION, trace('passed'), locale)).toBeNull();
+    },
+  );
+});
+
+describe('formatBanner — escalate decisions, English', () => {
+  it('passed: tells user a stronger model was used', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('passed', 1, ['mid-model']), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('stronger model was used');
+    expect(banner).toContain('first answer looked incomplete');
+  });
+
+  it('max_depth_reached: tells user the last attempt was also flagged', () => {
+    const banner = formatBanner(
+      ESCALATE_DECISION,
+      trace('max_depth_reached', 2, ['mid-model', 'strong-model']),
+      'en',
+    );
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('its answer was also flagged');
+  });
+
+  it('ladder_exhausted: tells user the strongest model was tried', () => {
+    const banner = formatBanner(
+      ESCALATE_DECISION,
+      trace('ladder_exhausted', 1, ['top-model']),
+      'en',
+    );
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('strongest available model');
+  });
+
+  it('model_not_on_ladder: tells user no stronger model is configured', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('model_not_on_ladder'), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('no stronger model is configured');
+  });
+
+  it('max_model_not_set: tells user max-mode has no target', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('max_model_not_set'), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('max-mode escalation has no target');
+  });
+
+  it('not_attempted: tells user escalation is disabled', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('not_attempted'), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('escalation is disabled');
+  });
+});
+
+describe('formatBanner — escalate decisions, German', () => {
+  it('passed: deutscher Text', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('passed', 1, ['mid-model']), 'de');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('stärkeres Modell wurde verwendet');
+  });
+
+  it('max_depth_reached: deutscher Text', () => {
+    const banner = formatBanner(
+      ESCALATE_DECISION,
+      trace('max_depth_reached', 2, ['mid-model', 'strong-model']),
+      'de-DE',
+    );
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('als unzureichend markiert');
+  });
+
+  it('ladder_exhausted: deutscher Text', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('ladder_exhausted'), 'de-AT');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('stärkste verfügbare Modell');
+  });
+
+  it('not_attempted: deutscher Text', () => {
+    const banner = formatBanner(ESCALATE_DECISION, trace('not_attempted'), 'de');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('Eskalation ist für diese Anfrage deaktiviert');
+  });
+});
+
+describe('formatBanner — skipped decisions', () => {
+  it('non_ok_status (en): tells user about downstream error', () => {
+    const decision: OrchestratorDecision = { kind: 'skipped', reason: 'non_ok_status' };
+    const banner = formatBanner(decision, trace('not_attempted'), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('error response');
+  });
+
+  it('non_ok_status (de): deutsche Fehlermeldung', () => {
+    const decision: OrchestratorDecision = { kind: 'skipped', reason: 'non_ok_status' };
+    const banner = formatBanner(decision, trace('not_attempted'), 'de');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('Fehlerantwort');
+  });
+
+  it('non_json_content_type (en): tells user response could not be evaluated', () => {
+    const decision: OrchestratorDecision = { kind: 'skipped', reason: 'non_json_content_type' };
+    const banner = formatBanner(decision, trace('not_attempted'), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('could not be evaluated');
+  });
+
+  it('streaming: returns null because banner does not apply to streamed responses', () => {
+    // The pipeline never calls formatBanner for streaming responses
+    // (ADR-0013 short-circuits before transparency injection runs),
+    // but the function defends against accidental calls by returning
+    // null for the streaming reason.
+    const decision: OrchestratorDecision = { kind: 'skipped', reason: 'streaming' };
+    expect(formatBanner(decision, trace('not_attempted'), 'en')).toBeNull();
+    expect(formatBanner(decision, trace('not_attempted'), 'de')).toBeNull();
+  });
+});
+
+describe('formatBannerPrefix', () => {
+  it('appends a blank line separator after the banner text', () => {
+    const prefix = formatBannerPrefix(
+      ESCALATE_DECISION,
+      trace('passed', 1, ['mid-model']),
+      'en',
+    );
+    expect(prefix).not.toBeNull();
+    expect(prefix!.endsWith('\n\n')).toBe(true);
+  });
+
+  it('returns null for pass decision', () => {
+    expect(formatBannerPrefix(PASS_DECISION, trace('passed'), 'en')).toBeNull();
+  });
+});

--- a/test/banner.test.ts
+++ b/test/banner.test.ts
@@ -49,14 +49,26 @@ describe('resolveBannerLocale', () => {
   });
 });
 
-describe('formatBanner — pass decisions return null', () => {
+describe('formatBanner — pass decisions, depth-aware', () => {
   it.each<string | undefined>(['en', 'de', undefined])(
-    'returns null for pass in locale %s',
+    'returns null for pass with depth=0 in locale %s',
     (locale) => {
       expect(formatBanner(PASS_DECISION, trace('passed'), locale)).toBeNull();
       expect(formatBannerPrefix(PASS_DECISION, trace('passed'), locale)).toBeNull();
     },
   );
+
+  it('emits a banner for pass with depth>0 (re-query produced a passing answer) — English', () => {
+    const banner = formatBanner(PASS_DECISION, trace('passed', 1, ['mid-model']), 'en');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('stronger model was used');
+  });
+
+  it('emits a banner for pass with depth>0 — German', () => {
+    const banner = formatBanner(PASS_DECISION, trace('passed', 1, ['mid-model']), 'de');
+    expect(banner).toContain('[turbocharger]');
+    expect(banner).toContain('stärkeres Modell wurde verwendet');
+  });
 });
 
 describe('formatBanner — escalate decisions, English', () => {

--- a/test/banner.test.ts
+++ b/test/banner.test.ts
@@ -183,11 +183,7 @@ describe('formatBanner — skipped decisions', () => {
 
 describe('formatBannerPrefix', () => {
   it('appends a blank line separator after the banner text', () => {
-    const prefix = formatBannerPrefix(
-      ESCALATE_DECISION,
-      trace('passed', 1, ['mid-model']),
-      'en',
-    );
+    const prefix = formatBannerPrefix(ESCALATE_DECISION, trace('passed', 1, ['mid-model']), 'en');
     expect(prefix).not.toBeNull();
     expect(prefix!.endsWith('\n\n')).toBe(true);
   });

--- a/test/pipeline-banner.test.ts
+++ b/test/pipeline-banner.test.ts
@@ -1,0 +1,343 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
+import type {
+  EscalationConfig,
+  OrchestratorConfig,
+  SignalWeights,
+  TransparencyConfig,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirror test/pipeline-escalation.test.ts)
+// ---------------------------------------------------------------------------
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  readonly baseUrl: string;
+  setHandler(handler: MockHandler): void;
+  bodies(): readonly Buffer[];
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+  const seen: Buffer[] = [];
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      seen.push(body);
+      Promise.resolve(handler(req, res, body)).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end(`mock-error: ${String(err)}`);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}/v1`,
+    setHandler(h) {
+      handler = h;
+    },
+    bodies() {
+      return seen;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+const DEFAULT_WEIGHTS: SignalWeights = {
+  refusal: 1,
+  truncation: 1,
+  repetition: 1,
+  empty: 1,
+  tool_error: 1,
+  syntax_error: 1,
+};
+
+function makeOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    threshold: 0.6,
+    weights: DEFAULT_WEIGHTS,
+    greyBand: [0.3, 0.6] as const,
+    ...overrides,
+  };
+}
+
+function makeEscalationConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
+  return {
+    mode: 'ladder',
+    ladder: ['weak-model', 'mid-model', 'strong-model'],
+    maxDepth: 2,
+    ...overrides,
+  };
+}
+
+function buildChatCompletionBody(content: string): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: 'stop',
+      },
+    ],
+  });
+}
+
+function extractContent(bodyText: string): string {
+  const obj = JSON.parse(bodyText) as {
+    choices: ReadonlyArray<{ message: { content: string } }>;
+  };
+  return obj.choices[0]!.message.content;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('pipeline transparency (banner)', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  function startSidecar(transparencyConfig?: TransparencyConfig): void {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig(),
+        ...(transparencyConfig !== undefined ? { transparencyConfig } : {}),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  }
+
+  it('prepends a banner to the assistant content when escalation succeeded', async () => {
+    startSidecar({ mode: 'banner' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const bodyText = await res.text();
+    const content = extractContent(bodyText);
+    expect(content.startsWith('[turbocharger] ')).toBe(true);
+    expect(content).toContain('stronger model was used');
+    // Original content is preserved AFTER the banner.
+    expect(content).toContain('clear, complete, helpful answer');
+
+    expect(logs[0]?.transparency_mode).toBe('banner');
+  });
+
+  it('does not prepend a banner when the first response passes', async () => {
+    startSidecar({ mode: 'banner' });
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Explain it briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger]')).toBe(false);
+    expect(content.startsWith('Here is a clear')).toBe(true);
+  });
+
+  it('does not prepend a banner when transparency mode is silent', async () => {
+    startSidecar({ mode: 'silent' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger]')).toBe(false);
+    // Headers still report the escalation
+    expect(res.headers.get('x-turbocharger-decision')).toBe('pass');
+    expect(res.headers.get('x-turbocharger-escalation-stopped')).toBe('passed');
+
+    expect(logs[0]?.transparency_mode).toBe('silent');
+  });
+
+  it('does not prepend a banner when no transparencyConfig is configured (silent default)', async () => {
+    startSidecar(); // No transparencyConfig — silent default.
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help."));
+      } else {
+        res.end(buildChatCompletionBody('A clear, helpful answer with details and context.'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger]')).toBe(false);
+    expect(logs[0]?.transparency_mode).toBeUndefined();
+  });
+
+  it('emits banner with not_attempted reason when escalation is disabled (maxDepth=0)', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({ maxDepth: 0 }),
+        transparencyConfig: { mode: 'banner' },
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, I cannot help."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger]')).toBe(true);
+    expect(content).toContain('escalation is disabled');
+    expect(content).toContain('original');
+    // The original refusal content is still after the banner
+    expect(content).toContain("I'm sorry, I cannot help.");
+  });
+
+  it('honors Accept-Language for German banners', async () => {
+    startSidecar({ mode: 'banner' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help."));
+      } else {
+        res.end(buildChatCompletionBody('Eine klare, hilfreiche Antwort mit Details.'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Language': 'de-DE,de;q=0.9,en;q=0.8',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Bitte helfen.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger] ')).toBe(true);
+    expect(content).toContain('stärkeres Modell');
+  });
+});


### PR DESCRIPTION
Closes #9. Implements the banner mode of the transparency layer per
brief §7. ADR-0022 records the design.

## What

Operators opt in via `transparencyConfig: { mode: 'banner' }` on
AppDeps. When opted in, escalation/skipped-with-reason decisions in
single-mode requests prepend a localized banner to the assistant
content:

    [turbocharger] A stronger model was used because the first answer
    looked incomplete. The answer below is from the stronger model.

    <original assistant content>

## Key decisions (ADR-0022)

- **Default is silent.** Operators MUST opt in by setting `mode:
  'banner'`. The brief §7 says "banner-as-default" for the
  user-facing vision; the technical default is silent so a
  misconfigured deployment does not silently mutate response bodies.
- **Body-mutating, not header-only.** Headers (`x-turbocharger-*`)
  already exist; end users don't read them.
- **Vague tone.** "Looked incomplete" not "was wrong" — the
  adequacy critic flagged a signal, not a proven inadequacy.
- **en + de locales** with BCP-47 prefix-match for German variants.
- **Chorus exempt** per ADR-0021. **Streaming exempt** per ADR-0013.

## Test count

133 → 171 passed (+32 unit, +6 integration).

## Bug found mid-implementation

A first version of the suppression rule (`return null for any
decision: pass`) was too eager: it suppressed banners in the
"escalation succeeded" case (re-query produced a passing answer,
depth > 0), which is the most informative case for transparency.
Fixed in commit `fix(transparency): emit banner when re-query
produces a passing answer` — suppression rule is now `decision: pass
AND depth === 0`. Two new unit tests guard the fixed behaviour.

## Out of scope

- Card mode (Issue #10)
- Per-request override via X-Turbocharger-Transparency header (Issue #12)
- Chorus-mode transparency (per ADR-0021)