### PR TITLE
docs: refresh all documentation post-Issue-9 / ADR-0021

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,133 @@
-# Contributing
+# Contributing to openclaw-turbocharger
 
-This project is in early scaffold stage. A full contribution guide will land
-alongside the `v0.1.0-alpha` release (see `PROJECT_BRIEF.md` §10, issue #15).
+Thanks for considering a contribution. This guide describes the
+working agreements that keep the project understandable as it grows.
+Most of these conventions exist because of a specific problem the
+project ran into; the rationale is in the linked ADR where one exists.
 
-Until then, the short version:
+## Workflow
 
-- **Open an issue before starting non-trivial work.** One issue per logical
-  change. Don't combine #2 with #3 in a single PR.
-- **Conventional Commits.** Examples: `feat(critic): implement hard-signal
-detector`, `fix(proxy): preserve request-id header on forward`,
-  `docs(readme): clarify escalation modes`.
-- **TypeScript strict mode.** No `any` without a comment explaining why.
-- **Runtime dependencies are deliberately kept minimal.** Target: fewer than
-  five. Adding one requires justification in the PR description. Dev
-  dependencies are less tightly constrained but should still be justified.
-- **Tests are required for new logic.** `vitest` for unit tests;
-  `test/e2e/**` for tests that need a live endpoint (those are opt-in and not
-  part of the default CI run).
-- **Tone of written artifacts** (README, docs, commit messages, issue
-  descriptions) is honest, technical, slightly dry, respectful toward related
-  projects, non-hype. See `PROJECT_BRIEF.md` §14.
-- **No overclaiming.** Phrases like "eliminates bias," "always picks the best
-  model," or "guaranteed savings" are out. Measured language only:
-  "reduces the chance of silent failures," "shows the user when escalation
-  happened," "may reduce cost depending on workload."
+- **Open an issue before non-trivial work.** A short description of
+  what you intend to change and why is enough. Issues are also where
+  design feedback happens before code is written.
+- **One issue per PR.** Don't combine #5 with #6 in a single
+  branch. The CI is fast enough that splitting is cheap, and
+  reviewers will thank you.
+- **Branch naming follows the issue type:**
+  - `feat/N-short-description` for new features (e.g.
+    `feat/9-transparency-banner`).
+  - `fix/short-description` for bug fixes.
+  - `docs/short-description` for documentation-only changes.
+  - `refactor/short-description` for code restructuring without
+    behaviour change (e.g. `refactor/chorus-as-answer-mode`).
+  - `chore/short-description` for tooling, dependencies, or
+    formatting commits that ship outside a feature branch.
+- **Commits use Conventional Commits.** Examples:
+  - `feat(critic): implement hard-signal detector`
+  - `fix(proxy): preserve request-id header on forward`
+  - `docs(readme): clarify escalation modes`
+  - `refactor(types): separate AnswerMode from EscalationMode`
+  - `chore: apply prettier to refactor files`
+  - `test(escalation): cover ladder exhaustion path`
+- **Rebase-and-merge, no squash.** The project's commit history is a
+  documented design narrative — every commit on `main` should still
+  be a meaningful unit you'd want to read in isolation. Squash-merging
+  loses that, fast-forward merging keeps unrelated commits adjacent,
+  rebase-and-merge is the compromise.
 
-## Decision log
+## Code
 
-Non-trivial architectural decisions are recorded in [`docs/DECISIONS.md`](./docs/DECISIONS.md).
-If your change makes or revises such a decision, add or update the entry in
-the same PR.
+- **TypeScript strict mode.** `tsconfig.json` enables
+  `exactOptionalPropertyTypes`, `verbatimModuleSyntax`, and
+  `noUncheckedIndexedAccess`. Most non-trivial type errors trace to
+  one of these — read the message carefully before reaching for
+  `any`. If `any` is genuinely the right answer, add a comment
+  explaining why; otherwise prefer `unknown` plus a narrowing check.
+- **Runtime dependencies stay minimal.** The project's contract is
+  fewer than five runtime dependencies (currently two: `hono` and
+  `@hono/node-server`). Adding one requires justification in the PR
+  description. Dev dependencies are less constrained but should
+  still be defended.
+- **No silent fallbacks that hide failures.** When a critic, proxy,
+  or escalation step can't do its job, surface the specific failure
+  through the discriminated result types — don't convert `error` or
+  `skipped` into an implicit `pass`. The pattern is in
+  [ADR-0012](./docs/DECISIONS.md) and applied consistently across
+  modules.
+- **No overclaiming.** "Eliminates bias", "always picks the best
+  model", "guaranteed savings" are out. Measured language only:
+  "reduces the chance of silent failures", "shows the user when
+  escalation happened", "may reduce cost depending on workload".
+  The project's brief (§14) calls this out specifically because
+  it's easy to slip into marketing tone in technical docs.
+
+## Tests
+
+- **`vitest` for unit tests.** Co-located under `test/`, named after
+  the module they exercise (e.g. `test/banner.test.ts` for
+  `src/transparency/banner.ts`).
+- **Integration tests live next to their unit tests** with a
+  `pipeline-` prefix when they exercise the full HTTP path
+  (e.g. `test/pipeline-banner.test.ts`).
+- **End-to-end tests** that need a live LLM endpoint live under
+  `test/e2e/` and are opt-in — they don't run in the default CI.
+- **New code paths get tests.** Especially for branches that handle
+  failure modes — the hardest bugs hide in the "should never
+  happen" branches.
+
+## Local verification
+
+Before pushing, run the full local pipeline:
+
+```bash
+pnpm check
+```
+
+This runs, in order: `prettier --write`, `eslint --fix`, `eslint`,
+`prettier --check`, `tsc --noEmit`, `vitest run`, `tsup`. Any step
+failing fails the whole command. CI runs the same steps but each
+in its own job, so a CI failure points to a specific stage.
+
+The `prettier --write` step normalises formatting silently. CI runs
+`prettier --check`, which doesn't, so format-drift can pass local
+verification but fail CI. The defence is to commit any formatting
+changes the local check makes — see the recurring `chore: apply
+prettier to ...` commits in the project history for the established
+pattern.
+
+## Architecture decisions
+
+Non-trivial architectural decisions are recorded in
+[`docs/DECISIONS.md`](./docs/DECISIONS.md) as numbered ADRs. The
+heuristic for "non-trivial" is: would a future contributor
+reading only the code be able to reconstruct why the decision was
+made the way it was? If not, write an ADR.
+
+Each ADR follows a short consistent shape:
+
+- **Date** (`YYYY-MM-DD`) and **status**
+  (`accepted` / `superseded by ADR-NNNN` / `deprecated`).
+- **Decision**: one paragraph stating what was decided, in the
+  imperative. No setup, no preamble.
+- **Rationale**: why this and not the obvious alternative.
+- **Alternatives considered**: explicit list with reasons for
+  rejection. The most useful section for future readers because it
+  documents the negative space.
+- **Consequences** or **Mechanical scope**: where applicable, what
+  this means for downstream code or other ADRs.
+- **Related**: cross-links to other ADRs, issues, or sections of
+  the brief.
+
+ADRs that supersede earlier ones don't delete them — the earlier
+record stays in place with a `Status: superseded` note so the
+project's evolution remains readable.
+
+## Tone of written artifacts
+
+The brief (§14, item 6) puts it best: "honest, technical, slightly
+dry, respectful toward related projects, non-hype". This applies to
+README, docs, commit messages, issue descriptions, ADRs, and
+changelog entries equally. Mistakes happen — own them in the next
+commit and move on. The project's history isn't supposed to look
+heroic; it's supposed to be useful to the next person who comes
+through.

--- a/README.md
+++ b/README.md
@@ -1,65 +1,130 @@
 # openclaw-turbocharger
 
-> Reactive model escalation sidecar for OpenClaw and any OpenAI-compatible client.
+> A sidecar that decides between running one model carefully and asking
+> several at once. For OpenClaw and any OpenAI-compatible client.
 
-**Status:** in-progress implementation. 5 of 15 MVP issues merged. The proxy,
-the adequacy detectors, the LLM-critic, the orchestrator, and the pipeline
-are in place; escalation, transparency, config-schema, and release wiring are
-still pending. No published release yet.
+**Status:** in-progress implementation. 9 of 15 MVP issues merged. The
+proxy, adequacy detectors, LLM-critic, orchestrator, pipeline, ladder
+escalation, max escalation, chorus dispatch stub, and the transparency
+banner are all in place. Card transparency, config schema, per-request
+overrides, the doc finalization round, and the first published release
+are still pending. No published release yet.
 
-openclaw-turbocharger fills the gap between "one cheap model for everything" and
-"one expensive model for everything." It runs whichever model you configured
-first, checks if the answer actually held up, and escalates only when signals
-say it didn't. You see the escalation when it happens and why.
+openclaw-turbocharger fills the gap between "one cheap model for everything"
+and "one expensive model for everything." It runs whichever model you
+configured first, checks if the answer actually held up, and escalates
+only when signals say it didn't. When that's not the question — when you
+want bias transparency and minority reports up front — it can also
+dispatch directly to a chorus endpoint instead. You see what happened
+when it happened.
 
 It is **not** a predictive router and **not** a replacement for existing
 OpenClaw routers (ClawRouter, iblai-openclaw-router, openmark-router,
-openrouter/auto). It complements them.
+openrouter/auto). It complements them. See
+[`docs/COMPARISON.md`](./docs/COMPARISON.md) for the longer version.
+
+## Two answer modes
+
+Per [ADR-0021](./docs/DECISIONS.md), the sidecar exposes two top-level
+paradigms for shaping a request:
+
+- **`single`** (the default): forward to the configured downstream
+  target, evaluate the response with the orchestrator, and — when an
+  escalation strategy is configured — re-query with a stronger model
+  until the answer passes or a stop condition is reached. This is the
+  reactive-escalation core the project was originally about.
+- **`chorus`** (opt-in): dispatch the request directly to a configured
+  chorus endpoint that synthesises a multi-model consensus answer with
+  bias transparency and minority reports. The orchestrator does not run
+  in this mode — chorus is itself the meta-adequacy mechanism, not
+  something that fires when adequacy fails.
+
+Single-mode users get reactive escalation. Chorus-mode users get
+deliberate consensus. They are orthogonal — not stages of the same
+process.
 
 ## What has landed
 
-The MVP is tracked as issues #2–#15 (see `PROJECT_BRIEF.md` §10). Merged so
-far, in order:
+The MVP is tracked as issues #2–#15 (see `PROJECT_BRIEF.md` §10). Merged
+so far, in order:
 
-1. **#2 `core`** — OpenAI-compatible HTTP server with pass-through proxy.
-   Forwards `POST /v1/chat/completions` to a configured downstream target
-   byte-for-byte, streams responses without buffering, preserves end-to-end
-   headers per RFC 7230.
+1. **#2 `core`** — OpenAI-compatible HTTP server with pass-through
+   proxy. Forwards `POST /v1/chat/completions` byte-for-byte, streams
+   responses without buffering, preserves end-to-end headers per RFC 7230.
 2. **#3 `critic:hard-signals`** — deterministic adequacy detectors for
    refusal, truncation, repetition, empty/short, tool-error, and JSON
-   syntax. Each detector emits a continuous confidence in `[0, 1]` so the
-   orchestrator can aggregate without losing weak-but-present evidence.
+   syntax. Each detector emits a continuous confidence in `[0, 1]` so
+   the orchestrator can aggregate without losing weak-but-present
+   evidence.
 3. **#4 `critic:llm`** — small-model LLM critic adapter. OpenAI-compatible,
    locale-keyed prompts (EN + DE), opt-in per-request budget check,
-   tolerant JSON extraction from the critic's response. Returns a
-   discriminated result so failure modes are never silently converted
-   into a pass.
-4. **#5 `critic:orchestrator` + pipeline** — combines hard signals (noisy-OR
-   aggregation with per-category weights) with the LLM-critic (invoked
-   only when the aggregate lands in a configurable grey band) into a
-   single decision. The pipeline wraps the proxy and surfaces the decision
-   as `X-Turbocharger-*` response headers and structured log fields.
+   tolerant JSON extraction. Returns a discriminated result so failure
+   modes are never silently converted into a pass.
+4. **#5 `critic:orchestrator` + pipeline** — combines hard signals
+   (noisy-OR aggregation with per-category weights) with the LLM-critic
+   (invoked only in a configurable grey band) into a single decision.
+   Surfaces it as `X-Turbocharger-*` response headers and structured
+   log fields.
+5. **#6 `escalation:ladder`** — on `escalate` decisions, re-queries with
+   the next step on a configured model ladder until the answer passes,
+   the ladder is exhausted, or `maxDepth` is reached.
+6. **#7 `escalation:max`** — alternative single-jump strategy: on
+   `escalate`, re-queries directly with a configured maxModel rather
+   than walking up a ladder.
+7. **#8 `escalation:chorus-stub`** (originally) — dispatch stub to an
+   external chorus endpoint, with classified errors
+   (`endpoint_not_set`, `unreachable`, `timeout`, `non_ok_status`) and
+   no silent fallback to other strategies.
+8. **ADR-0021** — refactor: chorus is re-classified from an escalation
+   mode to a parallel `AnswerMode`. See the linked ADR for the
+   rationale; the short version is that chorus is a user-selected
+   paradigm for multi-model consensus, not a reactive fallback for
+   adequacy failures.
+9. **#9 `transparency:banner`** — single-line localized banner
+   prepended to the assistant content when escalation/skipped-with-reason
+   happened in single mode. Banner mode is opt-in; the technical
+   default is silent. See [`docs/CONFIGURATION.md`](./docs/CONFIGURATION.md)
+   and [ADR-0022](./docs/DECISIONS.md).
 
-The full critic stack is now functional end-to-end — a request flows
-through the proxy, gets evaluated by the orchestrator, and its decision
-is visible to monitoring tools via response headers. What is still
-missing for a usable v0.1 is the escalation step that acts on the
-decision (re-querying with a stronger model) and the transparency layer
-that surfaces the decision to end users in the response body.
+## Transparency
+
+The transparency layer is opt-in. By default the sidecar reports
+escalation decisions on response headers (`x-turbocharger-decision`,
+`x-turbocharger-escalation-stopped`, `x-turbocharger-escalation-path`,
+…) and as structured log fields, but does not modify the response
+body. To make escalation events visible to end users, set
+`transparencyConfig.mode` to `banner`. Once opted in, an
+`[turbocharger]` annotation precedes the assistant content whenever
+escalation or skipped-with-reason happened:
+
+```
+[turbocharger] A stronger model was used because the first answer
+looked incomplete. The answer below is from the stronger model.
+
+<original assistant content>
+```
+
+The banner is locale-aware: `en-*` (default) and `de-*`. Other
+locales fall through to English. The phrasing is deliberately
+vague — "looked incomplete" rather than "was wrong" — because the
+adequacy critic flags signals, not proven inadequacy. See ADR-0022
+for the full reasoning.
+
+The card transparency mode (#10) will offer a more structured
+multi-line view as a third option alongside `silent` and `banner`.
 
 ## What lands next
 
-1. **#6 `escalation:ladder`** — on `escalate` decisions, re-query with the
-   next step on a configurable model ladder (e.g. haiku → sonnet → opus).
-2. **#7 `escalation:max`** — alternative mode: single jump to a configured
-   maximum-performance model instead of stepping up the ladder.
-3. **#9 `transparency:banner`** — short user-visible banner prepended or
-   appended to the response content when escalation happened.
-
-After that: the chorus stub (#8), the card transparency mode (#10), the
-Zod-validated config schema (#11), per-request header overrides (#12),
-README and comparison document finalization (#13 + #14), and the first
-published release (#15).
+1. **#10 `transparency:card`** — opt-in structured card view as an
+   alternative to the banner.
+2. **#11 `config:schema`** — Zod-validated config file shape merging
+   environment variables, file values, and defaults.
+3. **#12 `config:per-request-override`** — header-based per-request
+   overrides (`X-Turbocharger-Answer-Mode`, `X-Turbocharger-Transparency`,
+   …).
+4. **#13 / #14 `docs:readme` + `docs:comparison`** — final pass on the
+   README and the comparison document.
+5. **#15 `release:v0.1.0-alpha`** — first published version.
 
 ## Development
 
@@ -71,21 +136,38 @@ pnpm install
 pnpm check
 ```
 
-`pnpm check` runs the full local pipeline: format, lint, typecheck, test,
-build (see `docs/DECISIONS.md` ADR-0009). CI on every pull request runs
-each step separately for per-step failure reporting.
+`pnpm check` runs the full local pipeline: format, lint, typecheck,
+test, build (see `docs/DECISIONS.md` ADR-0009). CI on every pull
+request runs each step separately for per-step failure reporting.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full contribution
+workflow including ADR conventions, branch naming, and the local
+verification expectations.
 
 ## Kurzfassung (DE)
 
-`openclaw-turbocharger` ist ein provider-agnostischer Sidecar zwischen Client
-und Modell-Provider. Er führt die konfigurierte Default-Anfrage aus, prüft die
-Antwort anhand von Adäquanz-Signalen und eskaliert bei Bedarf auf ein stärkeres
-Modell. Eskalationen werden dem Nutzer standardmäßig transparent gemacht.
+`openclaw-turbocharger` ist ein provider-agnostischer Sidecar zwischen
+Client und Modell-Provider, der zwei Antwort-Paradigmen unterstützt:
 
-Stand: laufende Implementierung, 5 von 15 MVP-Issues gemerged. Proxy,
-Adäquanz-Detektoren, LLM-Kritiker, Orchestrator und Pipeline sind fertig;
-Eskalation, Transparenz-Layer, Config-Schema und Release-Verdrahtung
-stehen noch aus. Es gibt noch kein veröffentlichtes Release.
+- **`single`** (Standard): die konfigurierte Default-Anfrage ausführen,
+  die Antwort anhand von Adäquanz-Signalen prüfen und bei Bedarf auf
+  ein stärkeres Modell eskalieren (Ladder oder Max).
+- **`chorus`** (opt-in): die Anfrage direkt an einen Chorus-Endpoint
+  weiterleiten, der eine konsens-orientierte Multi-Modell-Antwort mit
+  Bias-Transparenz erzeugt. Der Orchestrator läuft in diesem Modus
+  nicht — Chorus ist selbst die Meta-Adäquanz-Logik.
+
+Eskalations-Ereignisse können über einen lokalisierten Banner
+(`mode: 'banner'`) im Antwort-Body sichtbar gemacht werden — opt-in,
+der technische Default ist `silent`. Banner-Texte sind in EN und DE
+verfügbar (Auswahl per `Accept-Language`).
+
+Stand: laufende Implementierung, 9 von 15 MVP-Issues gemerged. Proxy,
+Adäquanz-Detektoren, LLM-Kritiker, Orchestrator, Pipeline, Ladder-
+und Max-Eskalation, Chorus-Dispatch und Banner-Transparenz sind
+fertig. Card-Modus, Config-Schema, Per-Request-Overrides, finale
+Doku-Runde und das erste Release stehen noch aus. Es gibt noch kein
+veröffentlichtes Release.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,21 +1,147 @@
 # Architecture
 
-System-level architecture notes.
+System-level architecture of `openclaw-turbocharger` after the
+ADR-0021 refactor (Issue #8 + AnswerMode separation).
 
-## Status
+## Request lifecycle
 
-Scaffold. First real content lands with issue #2 (core proxy skeleton), which
-will include:
+The sidecar is itself an OpenAI-compatible HTTP server. Clients —
+OpenClaw, any other OpenAI-API-shaped client, or just `curl` —
+point at `http://localhost:<port>/v1/chat/completions` as if it
+were a model provider, and the sidecar handles routing, critic, and
+optional escalation behind that interface.
 
-- **HTTP framework choice.** A 3–5 line block naming the framework that was
-  chosen, the alternatives considered (`node:http`, `itty-router`, `hono` —
-  see brief §8), and a one-sentence rationale. The corresponding decision
-  record is `ADR-0003` in [`DECISIONS.md`](./DECISIONS.md).
-- **Request lifecycle diagram.** Text-based, matching the flow in
-  `PROJECT_BRIEF.md` §3.
-- **Module boundaries.** How `proxy`, `critic`, `escalation`, and
-  `transparency` compose, and the single shared type surface in
-  `src/types.ts`.
+```
+                    Client (OpenClaw, curl, …)
+                              │
+                              ▼
+    ┌──────────────────────────────────────────────────────────┐
+    │ Hono server (src/server.ts)                              │
+    │                                                          │
+    │   defaultAnswerMode === 'chorus' ? ──→ chorus path       │
+    │   else                          ──→ single path          │
+    └─────────────────────┬────────────────────────────────────┘
+                          │
+                ┌─────────┴────────────┐
+                │                      │
+                ▼                      ▼
+    ┌───────────────────────┐   ┌────────────────────────────┐
+    │ Single path           │   │ Chorus path                │
+    │ (src/pipeline.ts:     │   │ (src/pipeline.ts:          │
+    │  runSinglePipeline)   │   │  runChorusPipeline)        │
+    │                       │   │                            │
+    │ 1. Forward via proxy  │   │ 1. Forward request body    │
+    │ 2. Run orchestrator   │   │    + X-Turbocharger-*      │
+    │ 3. If escalate:       │   │    headers to              │
+    │    re-query next      │   │    ChorusConfig.endpoint   │
+    │    ladder/max step    │   │ 2. Forward response        │
+    │ 4. Loop until pass /  │   │    verbatim                │
+    │    maxDepth /         │   │                            │
+    │    ladder exhausted   │   │ Orchestrator does NOT run  │
+    │ 5. Inject banner if   │   │ on chorus responses (ADR-  │
+    │    transparencyConfig │   │ 0021): chorus is itself    │
+    │ 6. Return             │   │ the meta-adequacy layer.   │
+    └─────────┬─────────────┘   └────────────┬───────────────┘
+              │                              │
+              ▼                              ▼
+    Configured downstream                  Chorus endpoint
+    (Ollama, OpenAI, anthropic,            (openclaw-chorus or
+     openrouter, ClawRouter, …)             any compatible service)
+```
 
-For now, the authoritative architecture reference is `PROJECT_BRIEF.md` §3
-in the repository root.
+The two paths are deliberately separate. Single-mode requests pay
+for an orchestrator evaluation on every response and may pay for
+re-queries; chorus-mode requests pay for one chorus dispatch and
+nothing else. They are different paradigms, not stages of the
+same process. See ADR-0021 for the rationale.
+
+## Module map
+
+```
+src/
+├── server.ts          — HTTP entry. Hono app, AppDeps wiring,
+│                        decision-log emission. Branches on
+│                        defaultAnswerMode.
+├── pipeline.ts        — runPipeline + runSinglePipeline + runChorusPipeline.
+│                        Owns the escalation loop, chorus dispatch
+│                        invocation, banner injection, and response
+│                        annotation.
+├── proxy.ts           — forwardChatCompletion. Header-strip,
+│                        downstream call, body pass-through.
+├── types.ts           — single source of truth for the type
+│                        surface. AppConfig, AnswerMode,
+│                        OrchestratorConfig, EscalationConfig,
+│                        ChorusConfig, TransparencyConfig,
+│                        OrchestratorDecision, EscalationTrace,
+│                        ChorusTrace, etc.
+├── critic/
+│   ├── orchestrator.ts — runOrchestrator: combines hard-signals
+│   │                     (noisy-OR) with the optional LLM-critic
+│   │                     (grey-band invocation). Returns an
+│   │                     OrchestratorDecision discriminated union.
+│   ├── hard-signals.ts — six deterministic detectors, each
+│   │                     emitting a continuous confidence in [0, 1].
+│   ├── llm-critic.ts   — small-model adapter, OpenAI-compatible.
+│   │                     Returns a discriminated LlmCriticResult.
+│   └── index.ts        — barrel.
+├── escalation/
+│   ├── ladder.ts       — nextLadderStep, remainingLadderSteps.
+│   │                     Pure helpers, no I/O.
+│   ├── max.ts          — maxStep. Pure helper.
+│   └── index.ts        — barrel. No longer exports chorus dispatch
+│                          per ADR-0021.
+├── chorus/
+│   ├── dispatch.ts     — dispatchChorus. One HTTP call to a
+│   │                     ChorusConfig.endpoint, classified errors,
+│   │                     no silent fallback.
+│   └── index.ts        — barrel.
+├── transparency/
+│   ├── banner.ts       — formatBanner, formatBannerPrefix,
+│   │                     resolveBannerLocale. Pure functions, no I/O.
+│   ├── card.ts         — placeholder for issue #10.
+│   └── logger.ts       — placeholder for structured log helpers.
+└── config/
+    └── env.ts          — loadEnvConfig. Reads TURBOCHARGER_* env
+                          vars into AppConfig. The full file-based
+                          loader arrives with issue #11.
+```
+
+## Type surface
+
+`src/types.ts` is the single shared type surface. Every module
+imports its types from there; modules do not export types that
+other modules consume directly. This keeps the dependency graph
+flat — `critic/`, `escalation/`, `chorus/`, and `transparency/`
+all depend on `types.ts` and never on each other for types.
+
+The discriminated unions (`OrchestratorDecision`,
+`LlmCriticResult`, `ChorusDispatchResult`) follow the project's
+"no silent fallbacks" principle from the brief: failure modes are
+always representable in the type, never converted into an
+implicit success.
+
+## Decisions
+
+The numbered ADRs in [`DECISIONS.md`](./DECISIONS.md) record the
+non-trivial architectural decisions and the alternatives that
+were rejected. Particularly relevant for understanding the
+current shape:
+
+- **ADR-0006** — noisy-OR aggregation of hard signals.
+- **ADR-0010 / ADR-0011** — grey-band invocation of the LLM-critic
+  and the rule that LLM verdicts do not feed into the noisy-OR.
+- **ADR-0013** — streaming responses skip the orchestrator
+  entirely.
+- **ADR-0016** — escalation strategies share the single configured
+  downstream.
+- **ADR-0018 / ADR-0019** — `maxDepth` semantics and the rule that
+  max-mode without `maxModel` is a configuration error, not a
+  silent fallback.
+- **ADR-0020** — chorus dispatch is hard-fail.
+- **ADR-0021** — chorus is an `AnswerMode`, not an escalation
+  strategy. The most consequential refactor in the project so far.
+- **ADR-0022** — transparency banner is opt-in, body-mutating, and
+  locale-aware.
+
+The full project-level brief lives in `PROJECT_BRIEF.md` at the
+repository root and remains the design-intent reference.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,20 +1,131 @@
 # Comparison to related projects
 
-Honest, respectful comparison to the routers in the OpenClaw ecosystem.
+This document positions `openclaw-turbocharger` against the OpenClaw
+router ecosystem in early 2026. The intent is factual orientation,
+not competitive marketing — the projects below are well-engineered
+and solve different problems than this one. We complement them more
+often than we replace them.
 
-## Status
+## Reactive vs predictive routing
 
-Scaffold. Lands with issue #14.
+The OpenClaw router space is dominated by **predictive** routers:
+they look at a user query, score its complexity (keyword heuristics,
+embeddings, benchmark results), and pick a model up front. The user
+gets one answer from the model the router judged appropriate.
 
-Projects to cover (per `PROJECT_BRIEF.md` §12):
+`openclaw-turbocharger` is **reactive**: it forwards the request to
+the model the user (or an upstream router) chose, evaluates the
+*response*, and only then decides whether a stronger model should be
+tried. The two approaches answer different questions:
 
-- **ClawRouter** (BlockRunAI) — most-starred predictive router, cascade on
-  roadmap. We differ in: provider-agnostic design, no crypto/wallet
-  dependency, EU-compatible, chorus bridge.
-- **iblai-openclaw-router** (ibl.ai) — clean zero-dependency 14-dimension
-  predictive router.
-- **openmark-router** (OpenMark AI) — benchmark-driven predictive router.
-- **openrouter/auto** — OpenRouter's built-in auto model selector.
+- _Predictive:_ "given this query, which model should run it?"
+- _Reactive:_ "given this answer, did the model that ran it actually
+  produce something usable?"
 
-The comparison will be factual — linking to upstream roadmaps, documenting
-differences without framing them as shortcomings of the other projects.
+A predictive router can be wrong about a query's complexity and
+nobody notices — the user receives the inadequate answer. A reactive
+sidecar can mis-classify an adequate answer as inadequate and
+trigger a needless escalation, costing time and money. Each failure
+mode has a cost; the right tool depends on which cost matters more
+in the deployment.
+
+The two paradigms compose: a predictive router can be the
+turbocharger's downstream target, and the turbocharger will react
+to whatever model the router chose.
+
+## Quick comparison
+
+The columns below cover the differentiating axes for the OpenClaw
+router space in early 2026. "Yes/No" judgements are based on each
+project's published documentation; corrections welcome via PR.
+
+| Project                          | Approach           | Multi-model consensus | EU-compatible | Crypto / wallet dependency | License |
+| -------------------------------- | ------------------ | --------------------- | ------------- | -------------------------- | ------- |
+| `openclaw-turbocharger`          | Reactive escalation + chorus answer mode | Yes (chorus mode) | Yes           | No                         | MIT     |
+| ClawRouter (BlockRunAI)          | Predictive (cascade on roadmap) | No        | Limited       | Yes                        | MIT     |
+| iblai-openclaw-router (ibl.ai)   | Predictive (14-dimension)       | No        | Yes           | No                         | MIT     |
+| openmark-router (OpenMark AI)    | Predictive (benchmark-driven)   | No        | Yes           | No                         | MIT     |
+| openrouter/auto                  | Predictive (proprietary)        | No        | Yes           | No                         | Closed  |
+
+"EU-compatible" here means the project does not require integration
+with crypto-payment flows or token-based payment rails that conflict
+with MiCA, DSGVO, or typical enterprise procurement. This is a
+deployment concern, not a code-quality judgement.
+
+## Per-project notes
+
+### ClawRouter (BlockRunAI)
+
+The most-starred predictive router in the OpenClaw ecosystem. Its
+public roadmap mentions cascade routing — "try cheap model first,
+escalate on low quality" — as a planned feature. We're building
+independently rather than waiting on or coordinating with that
+roadmap, with three concrete differences:
+
+- **Provider-agnostic.** ClawRouter is opinionated about its
+  preferred providers. The turbocharger sits in front of any
+  OpenAI-compatible endpoint, including ClawRouter itself.
+- **No crypto payment dependency.** ClawRouter's billing model
+  involves on-chain settlement. The turbocharger has no such
+  requirement, which makes it deployable in EU enterprise contexts
+  where on-chain payment flows are not acceptable.
+- **Chorus answer mode.** Per ADR-0021 the turbocharger exposes
+  multi-model consensus (chorus) as a parallel paradigm to single
+  escalation. ClawRouter's roadmap does not.
+
+### iblai-openclaw-router (ibl.ai)
+
+A clean, zero-runtime-dependency 14-dimension predictive router.
+Excellent for deployments that want a small, auditable router with
+no external integrations. The turbocharger can run in front of or
+behind it — as a downstream target if the router pre-selects, or
+as a sidecar that reacts to whatever the router picked.
+
+### openmark-router (OpenMark AI)
+
+Benchmark-driven: routes based on each model's measured performance
+on a curated test set. Strong fit when the benchmark methodology
+matches the deployment's actual workload, less strong when the
+workload diverges from the benchmark distribution. Complementary to
+the turbocharger: openmark picks an adequate-looking model, the
+turbocharger reacts if the actual response disagrees.
+
+### openrouter/auto
+
+OpenRouter's built-in auto model selector. Hosted, proprietary, and
+the lowest-friction predictive router in the space. Not directly
+comparable to a self-hosted sidecar like the turbocharger, but a
+common downstream target — a turbocharger deployment can point at
+`openrouter/auto` and let the routing happen there, while still
+catching adequacy failures with the orchestrator on top.
+
+## Inspirations and adjacent work
+
+- **`karpathy/llm-council`** — the inspiration for the chorus
+  paradigm. Not integrated with this project, but the conceptual
+  ancestor of the chorus answer mode and the future
+  `openclaw-chorus` project.
+- **Council Mode (arXiv)** — academic validation of multi-model
+  council architectures. Cited in the future `openclaw-chorus`
+  project, not directly here.
+
+## When to use what
+
+Pick the tool whose failure mode matters less for your deployment:
+
+- **Predictive router only** when query distribution is well-known
+  ahead of time and the cost of one model running every query is
+  acceptable (the predictor's job is just to pick the cheapest
+  acceptable model).
+- **Reactive sidecar (turbocharger, single mode)** when adequacy
+  failures are a real cost — refusals, truncations, tool-call
+  errors that a predictive router can't see because they only show
+  up in the response.
+- **Chorus mode (turbocharger or a chorus-capable backend)** when
+  the question is contentious or important enough to deserve more
+  than one model's view — bias transparency and minority reports
+  are first-class outputs.
+- **Predictive router + reactive sidecar** when the deployment can
+  afford both: the predictive router minimises the common case,
+  the sidecar catches the residual adequacy failures the
+  predictor mis-classified.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -15,7 +15,7 @@ gets one answer from the model the router judged appropriate.
 
 `openclaw-turbocharger` is **reactive**: it forwards the request to
 the model the user (or an upstream router) chose, evaluates the
-*response*, and only then decides whether a stronger model should be
+_response_, and only then decides whether a stronger model should be
 tried. The two approaches answer different questions:
 
 - _Predictive:_ "given this query, which model should run it?"
@@ -39,13 +39,13 @@ The columns below cover the differentiating axes for the OpenClaw
 router space in early 2026. "Yes/No" judgements are based on each
 project's published documentation; corrections welcome via PR.
 
-| Project                          | Approach           | Multi-model consensus | EU-compatible | Crypto / wallet dependency | License |
-| -------------------------------- | ------------------ | --------------------- | ------------- | -------------------------- | ------- |
-| `openclaw-turbocharger`          | Reactive escalation + chorus answer mode | Yes (chorus mode) | Yes           | No                         | MIT     |
-| ClawRouter (BlockRunAI)          | Predictive (cascade on roadmap) | No        | Limited       | Yes                        | MIT     |
-| iblai-openclaw-router (ibl.ai)   | Predictive (14-dimension)       | No        | Yes           | No                         | MIT     |
-| openmark-router (OpenMark AI)    | Predictive (benchmark-driven)   | No        | Yes           | No                         | MIT     |
-| openrouter/auto                  | Predictive (proprietary)        | No        | Yes           | No                         | Closed  |
+| Project                        | Approach                                 | Multi-model consensus | EU-compatible | Crypto / wallet dependency | License |
+| ------------------------------ | ---------------------------------------- | --------------------- | ------------- | -------------------------- | ------- |
+| `openclaw-turbocharger`        | Reactive escalation + chorus answer mode | Yes (chorus mode)     | Yes           | No                         | MIT     |
+| ClawRouter (BlockRunAI)        | Predictive (cascade on roadmap)          | No                    | Limited       | Yes                        | MIT     |
+| iblai-openclaw-router (ibl.ai) | Predictive (14-dimension)                | No                    | Yes           | No                         | MIT     |
+| openmark-router (OpenMark AI)  | Predictive (benchmark-driven)            | No                    | Yes           | No                         | MIT     |
+| openrouter/auto                | Predictive (proprietary)                 | No                    | Yes           | No                         | Closed  |
 
 "EU-compatible" here means the project does not require integration
 with crypto-payment flows or token-based payment rails that conflict

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,12 +1,234 @@
 # Configuration Reference
 
-Full configuration reference for `openclaw-turbocharger`.
+Configuration reference for `openclaw-turbocharger`. All types
+below correspond directly to interfaces in
+[`src/types.ts`](../src/types.ts) — that file remains the
+authoritative source of truth.
 
 ## Status
 
-Scaffold. Lands with issue #11 (Zod schema) and is expanded in parallel
-with subsequent issues.
+The configuration shape is settled at the TypeScript level. A
+Zod-validated config file shape lands with issue #11 and may
+adjust naming or add validation; the underlying interfaces here
+will not change without an ADR.
 
-For now, the illustrative config shape in `PROJECT_BRIEF.md` §5 is the
-source of truth. Example configs (not yet validated against a live
-schema) live under [`examples/`](../examples).
+The example configs under [`examples/`](../examples) are
+illustrative — they show the eventual file shape but are not yet
+parsed by the running sidecar (which currently reads its
+configuration from environment variables, see below).
+
+## Top-level shape
+
+A turbocharger deployment has up to six configuration objects, each
+optional unless its feature is in use:
+
+```text
+AppConfig                   — port + downstream target (always required)
+OrchestratorConfig          — adequacy critic settings (single mode)
+EscalationConfig            — ladder/max strategy (single mode + escalate)
+ChorusConfig                — chorus endpoint (chorus mode only)
+TransparencyConfig          — banner/silent (display)
+defaultAnswerMode: AnswerMode — single (default) or chorus
+```
+
+The breakdown below matches that order.
+
+## `AppConfig`
+
+The minimum viable configuration. Every deployment needs this.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `port` | `number` | Yes | TCP port the sidecar listens on. |
+| `downstreamBaseUrl` | `string` | Yes | OpenAI-compatible base URL. Trailing slashes are normalised away. |
+| `downstreamApiKey` | `string` | No | Bearer token injected as `Authorization: Bearer <key>` when the upstream client did not supply one. |
+
+Examples of `downstreamBaseUrl`:
+`http://localhost:11434/v1` (Ollama),
+`https://api.openai.com/v1`,
+`https://api.anthropic.com/v1`,
+or another router like `https://openrouter.ai/api/v1`.
+
+## `AnswerMode`
+
+Selects the high-level paradigm for shaping the answer:
+
+```ts
+type AnswerMode = 'single' | 'chorus';
+```
+
+- `'single'` (default): forward to the configured downstream
+  target, evaluate the response, optionally escalate. The reactive
+  core of the project. See `OrchestratorConfig` and `EscalationConfig`.
+- `'chorus'`: dispatch directly to a configured chorus endpoint
+  that synthesises a multi-model consensus answer. The
+  orchestrator does not run in this mode. See `ChorusConfig`.
+
+The mode is set on `AppDeps` as `defaultAnswerMode` and applies to
+every request. Per-request overrides via the
+`X-Turbocharger-Answer-Mode` header arrive with issue #12.
+
+## `OrchestratorConfig`
+
+Tunes the adequacy critic. Required for single-mode requests when
+the orchestrator should run; absent means pass-through proxy
+behaviour.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `threshold` | `number` | — | Escalation threshold for the noisy-OR aggregate (`[0, 1]`). ADR-0006 recommends `0.6`. |
+| `weights` | `SignalWeights` | — | Per-category multiplier applied to each signal's confidence before aggregation. |
+| `greyBand` | `[number, number]` | `[0.30, 0.60]` (recommended) | Range in which the LLM-critic is invoked, when configured. ADR-0010. |
+| `llmCritic` | `{ run, config }` | absent | Optional LLM-critic. When present, runs only inside the grey band. |
+
+`SignalWeights` covers six categories: `refusal`, `truncation`,
+`repetition`, `empty`, `tool_error`, `syntax_error`. A weight of
+`0` disables the category. The brief recommends starting weights
+at `1.0` and tuning per workload.
+
+## `EscalationConfig`
+
+Tells the pipeline what to do when the orchestrator decides
+`escalate`. Only consulted in `single` answer mode.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mode` | `'ladder' \| 'max'` | Yes | Strategy. ADR-0021 reduced this from three to two — chorus is no longer an escalation strategy. |
+| `ladder` | `string[]` | Yes (use `[]` for max-only) | Ordered weak-to-strong list of model ids understood by the downstream target. |
+| `maxModel` | `string` | Required when `mode === 'max'` | Single jump target. Per ADR-0019 there is no implicit fallback; missing `maxModel` in max mode produces a `max_model_not_set` stop. |
+| `maxDepth` | `number` | Yes | Maximum escalation steps. `0` disables escalation entirely (decisions still reported via headers). ADR-0018 recommends `2`. |
+
+Per ADR-0016 all ladder steps share the single configured downstream
+target — there are no per-model `baseUrl` overrides in v0.1.
+
+## `ChorusConfig`
+
+Configures chorus dispatch. Required when `defaultAnswerMode` is
+`chorus`; ignored otherwise. ADR-0021 separates this from
+`EscalationConfig` because chorus is an answer paradigm, not an
+escalation strategy.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `endpoint` | `string` | Yes | URL of the chorus endpoint. OpenAI-compatible: receives a standard chat/completions request body plus `X-Turbocharger-*` context headers. |
+| `timeoutMs` | `number` | No (default `90_000`) | Per-request timeout. Chorus endpoints are slower than single-model calls because they fan out internally; ADR-0020 documents the 90-second default. |
+
+Per ADR-0020 (retained under ADR-0021), chorus dispatch is
+hard-fail. Missing, unreachable, timing-out, or
+error-responding endpoints surface specific outcomes
+(`endpoint_not_set`, `unreachable`, `timeout`, `non_ok_status`)
+rather than falling back to single mode.
+
+## `TransparencyConfig`
+
+Controls whether escalation events are surfaced in the response
+body to end users. Decisions are always reported as
+`x-turbocharger-*` response headers and structured log fields
+regardless of this setting.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mode` | `'banner' \| 'silent'` | Yes when transparencyConfig is supplied | Body-level display mode. The `'card'` mode arrives with issue #10. |
+
+**The technical default is silent.** Per [ADR-0022](./DECISIONS.md), a
+sidecar started without an explicit `transparencyConfig` does not
+modify response bodies — even when escalation happens. Operators
+who want end users to see escalation events MUST opt in by setting
+`transparencyConfig: { mode: 'banner' }`. This is a deliberate
+choice: response-body mutation is invasive enough that it should
+only happen when the operator has consciously chosen it.
+
+When opted in, the banner is a single line marked with
+`[turbocharger]` and a blank line separator, prepended to
+`choices[0].message.content`. Banner text is locale-aware (English
+default, German for `de-*`). Pass decisions on the first try
+(`depth === 0`) produce no banner. Streaming responses (per
+ADR-0013) and chorus-mode responses (per ADR-0021) are exempt.
+
+## Environment variables
+
+For deployments that don't yet use the file-based config (most
+of them, since #11 hasn't landed), `loadEnvConfig` reads the
+following:
+
+| Variable | Type | Required | Maps to |
+| --- | --- | --- | --- |
+| `TURBOCHARGER_PORT` | number | No (default `11435`) | `AppConfig.port` |
+| `TURBOCHARGER_DOWNSTREAM_BASE_URL` | string | Yes | `AppConfig.downstreamBaseUrl` |
+| `TURBOCHARGER_DOWNSTREAM_API_KEY` | string | No | `AppConfig.downstreamApiKey` |
+
+Other config objects (orchestrator, escalation, chorus,
+transparency) are wired in code via `AppDeps` for now. The full
+file-based configuration loader arrives with issue #11.
+
+## Example deployments
+
+The `examples/` directory has two illustrative configs in YAML and
+JSON. They show the eventual file shape (post-issue-#11). For the
+moment, treat them as design intent — the running sidecar reads
+its configuration from environment variables and `AppDeps` as
+described above.
+
+### Minimal: pass-through proxy
+
+```yaml
+turbocharger:
+  port: 11435
+  downstream_base_url: http://localhost:11434/v1
+```
+
+### Single mode with ladder escalation and banner transparency
+
+```yaml
+turbocharger:
+  port: 11435
+  downstream_base_url: http://localhost:11434/v1
+
+  answer_mode: single
+
+  orchestrator:
+    threshold: 0.6
+    grey_band: [0.30, 0.60]
+    weights:
+      refusal: 1.0
+      truncation: 1.0
+      repetition: 1.0
+      empty: 1.0
+      tool_error: 1.0
+      syntax_error: 1.0
+    llm_critic:
+      base_url: http://localhost:11434/v1
+      model: qwen2.5:7b
+      budget_usd: 0.01
+
+  escalation:
+    mode: ladder
+    ladder:
+      - ollama/qwen2.5:7b
+      - anthropic/claude-haiku-4-5
+      - anthropic/claude-sonnet-4-6
+      - anthropic/claude-opus-4-7
+    max_depth: 2
+
+  transparency:
+    mode: banner
+```
+
+### Chorus mode
+
+```yaml
+turbocharger:
+  port: 11435
+  downstream_base_url: http://localhost:11434/v1
+
+  answer_mode: chorus
+
+  chorus:
+    endpoint: http://localhost:11436/v1/chat/completions
+    timeout_ms: 90000
+```
+
+When chorus is the default answer mode, the sidecar bypasses the
+orchestrator and the escalation loop entirely — the chorus
+endpoint is responsible for the multi-model synthesis and the
+sidecar forwards its response unchanged.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,11 +37,11 @@ The breakdown below matches that order.
 
 The minimum viable configuration. Every deployment needs this.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `port` | `number` | Yes | TCP port the sidecar listens on. |
-| `downstreamBaseUrl` | `string` | Yes | OpenAI-compatible base URL. Trailing slashes are normalised away. |
-| `downstreamApiKey` | `string` | No | Bearer token injected as `Authorization: Bearer <key>` when the upstream client did not supply one. |
+| Field               | Type     | Required | Description                                                                                         |
+| ------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `port`              | `number` | Yes      | TCP port the sidecar listens on.                                                                    |
+| `downstreamBaseUrl` | `string` | Yes      | OpenAI-compatible base URL. Trailing slashes are normalised away.                                   |
+| `downstreamApiKey`  | `string` | No       | Bearer token injected as `Authorization: Bearer <key>` when the upstream client did not supply one. |
 
 Examples of `downstreamBaseUrl`:
 `http://localhost:11434/v1` (Ollama),
@@ -74,12 +74,12 @@ Tunes the adequacy critic. Required for single-mode requests when
 the orchestrator should run; absent means pass-through proxy
 behaviour.
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `threshold` | `number` | — | Escalation threshold for the noisy-OR aggregate (`[0, 1]`). ADR-0006 recommends `0.6`. |
-| `weights` | `SignalWeights` | — | Per-category multiplier applied to each signal's confidence before aggregation. |
-| `greyBand` | `[number, number]` | `[0.30, 0.60]` (recommended) | Range in which the LLM-critic is invoked, when configured. ADR-0010. |
-| `llmCritic` | `{ run, config }` | absent | Optional LLM-critic. When present, runs only inside the grey band. |
+| Field       | Type               | Default                      | Description                                                                            |
+| ----------- | ------------------ | ---------------------------- | -------------------------------------------------------------------------------------- |
+| `threshold` | `number`           | —                            | Escalation threshold for the noisy-OR aggregate (`[0, 1]`). ADR-0006 recommends `0.6`. |
+| `weights`   | `SignalWeights`    | —                            | Per-category multiplier applied to each signal's confidence before aggregation.        |
+| `greyBand`  | `[number, number]` | `[0.30, 0.60]` (recommended) | Range in which the LLM-critic is invoked, when configured. ADR-0010.                   |
+| `llmCritic` | `{ run, config }`  | absent                       | Optional LLM-critic. When present, runs only inside the grey band.                     |
 
 `SignalWeights` covers six categories: `refusal`, `truncation`,
 `repetition`, `empty`, `tool_error`, `syntax_error`. A weight of
@@ -91,12 +91,12 @@ at `1.0` and tuning per workload.
 Tells the pipeline what to do when the orchestrator decides
 `escalate`. Only consulted in `single` answer mode.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `mode` | `'ladder' \| 'max'` | Yes | Strategy. ADR-0021 reduced this from three to two — chorus is no longer an escalation strategy. |
-| `ladder` | `string[]` | Yes (use `[]` for max-only) | Ordered weak-to-strong list of model ids understood by the downstream target. |
-| `maxModel` | `string` | Required when `mode === 'max'` | Single jump target. Per ADR-0019 there is no implicit fallback; missing `maxModel` in max mode produces a `max_model_not_set` stop. |
-| `maxDepth` | `number` | Yes | Maximum escalation steps. `0` disables escalation entirely (decisions still reported via headers). ADR-0018 recommends `2`. |
+| Field      | Type                | Required                       | Description                                                                                                                         |
+| ---------- | ------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`     | `'ladder' \| 'max'` | Yes                            | Strategy. ADR-0021 reduced this from three to two — chorus is no longer an escalation strategy.                                     |
+| `ladder`   | `string[]`          | Yes (use `[]` for max-only)    | Ordered weak-to-strong list of model ids understood by the downstream target.                                                       |
+| `maxModel` | `string`            | Required when `mode === 'max'` | Single jump target. Per ADR-0019 there is no implicit fallback; missing `maxModel` in max mode produces a `max_model_not_set` stop. |
+| `maxDepth` | `number`            | Yes                            | Maximum escalation steps. `0` disables escalation entirely (decisions still reported via headers). ADR-0018 recommends `2`.         |
 
 Per ADR-0016 all ladder steps share the single configured downstream
 target — there are no per-model `baseUrl` overrides in v0.1.
@@ -108,9 +108,9 @@ Configures chorus dispatch. Required when `defaultAnswerMode` is
 `EscalationConfig` because chorus is an answer paradigm, not an
 escalation strategy.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `endpoint` | `string` | Yes | URL of the chorus endpoint. OpenAI-compatible: receives a standard chat/completions request body plus `X-Turbocharger-*` context headers. |
+| Field       | Type     | Required              | Description                                                                                                                                         |
+| ----------- | -------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`  | `string` | Yes                   | URL of the chorus endpoint. OpenAI-compatible: receives a standard chat/completions request body plus `X-Turbocharger-*` context headers.           |
 | `timeoutMs` | `number` | No (default `90_000`) | Per-request timeout. Chorus endpoints are slower than single-model calls because they fan out internally; ADR-0020 documents the 90-second default. |
 
 Per ADR-0020 (retained under ADR-0021), chorus dispatch is
@@ -126,8 +126,8 @@ body to end users. Decisions are always reported as
 `x-turbocharger-*` response headers and structured log fields
 regardless of this setting.
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
+| Field  | Type                   | Required                                | Description                                                        |
+| ------ | ---------------------- | --------------------------------------- | ------------------------------------------------------------------ |
 | `mode` | `'banner' \| 'silent'` | Yes when transparencyConfig is supplied | Body-level display mode. The `'card'` mode arrives with issue #10. |
 
 **The technical default is silent.** Per [ADR-0022](./DECISIONS.md), a
@@ -151,11 +151,11 @@ For deployments that don't yet use the file-based config (most
 of them, since #11 hasn't landed), `loadEnvConfig` reads the
 following:
 
-| Variable | Type | Required | Maps to |
-| --- | --- | --- | --- |
-| `TURBOCHARGER_PORT` | number | No (default `11435`) | `AppConfig.port` |
-| `TURBOCHARGER_DOWNSTREAM_BASE_URL` | string | Yes | `AppConfig.downstreamBaseUrl` |
-| `TURBOCHARGER_DOWNSTREAM_API_KEY` | string | No | `AppConfig.downstreamApiKey` |
+| Variable                           | Type   | Required             | Maps to                       |
+| ---------------------------------- | ------ | -------------------- | ----------------------------- |
+| `TURBOCHARGER_PORT`                | number | No (default `11435`) | `AppConfig.port`              |
+| `TURBOCHARGER_DOWNSTREAM_BASE_URL` | string | Yes                  | `AppConfig.downstreamBaseUrl` |
+| `TURBOCHARGER_DOWNSTREAM_API_KEY`  | string | No                   | `AppConfig.downstreamApiKey`  |
 
 Other config objects (orchestrator, escalation, chorus,
 transparency) are wired in code via `AppDeps` for now. The full

--- a/examples/openclaw-config.example.json
+++ b/examples/openclaw-config.example.json
@@ -1,23 +1,43 @@
 {
-  "_note": "ILLUSTRATIVE example config — JSON variant of examples/standalone-config.example.yaml. Not yet validated against a live schema (schema lands with issue #11). Keys and types may change before v0.1.0-alpha.",
+  "_note": "ILLUSTRATIVE example config — JSON variant of examples/standalone-config.example.yaml. Mirrors the type surface in src/types.ts but is not yet validated against a live schema (schema lands with issue #11). See docs/CONFIGURATION.md for the field-by-field reference. Transparency mode is set to 'banner' here to demonstrate the opt-in deployment shape; the technical default is 'silent'.",
   "turbocharger": {
-    "default_escalation": "ladder",
-    "ladder": [
-      "ollama/qwen2.5:7b",
-      "anthropic/claude-haiku-4-5",
-      "anthropic/claude-sonnet-4-6",
-      "anthropic/claude-opus-4-7"
-    ],
-    "max_model": "anthropic/claude-opus-4-7",
-    "chorus_endpoint": null,
-    "max_escalation_depth": 2,
-    "critic": {
-      "strategy": "hybrid",
-      "llm_model": "ollama/qwen2.5:7b",
-      "critic_budget_usd": 0.01
+    "port": 11435,
+    "downstream_base_url": "http://localhost:11434/v1",
+    "answer_mode": "single",
+    "orchestrator": {
+      "threshold": 0.6,
+      "grey_band": [0.3, 0.6],
+      "weights": {
+        "refusal": 1.0,
+        "truncation": 1.0,
+        "repetition": 1.0,
+        "empty": 1.0,
+        "tool_error": 1.0,
+        "syntax_error": 1.0
+      },
+      "llm_critic": {
+        "base_url": "http://localhost:11434/v1",
+        "model": "qwen2.5:7b",
+        "budget_usd": 0.01
+      }
+    },
+    "escalation": {
+      "mode": "ladder",
+      "ladder": [
+        "ollama/qwen2.5:7b",
+        "anthropic/claude-haiku-4-5",
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-opus-4-7"
+      ],
+      "max_model": "anthropic/claude-opus-4-7",
+      "max_depth": 2
+    },
+    "chorus": {
+      "endpoint": null,
+      "timeout_ms": 90000
     },
     "transparency": {
-      "default": "banner"
+      "mode": "banner"
     }
   }
 }

--- a/examples/standalone-config.example.yaml
+++ b/examples/standalone-config.example.yaml
@@ -1,39 +1,70 @@
 # openclaw-turbocharger — standalone config example
 #
-# Status: ILLUSTRATIVE. This example mirrors the shape in PROJECT_BRIEF.md §5
-# but is not yet validated against a live schema (schema lands with issue #11).
-# Keys and types may still change before v0.1.0-alpha.
+# Status: ILLUSTRATIVE. This example mirrors the type surface in
+# src/types.ts but is not yet validated against a live schema (schema
+# lands with issue #11). Keys and types may still change before
+# v0.1.0-alpha. See docs/CONFIGURATION.md for the field-by-field
+# reference.
 
 turbocharger:
-  # Which escalation strategy fires on critic-fail.
-  # ladder | max | chorus
-  default_escalation: ladder
+  port: 11435
+  downstream_base_url: http://localhost:11434/v1
 
-  # Ordered chain used by the `ladder` strategy. Each step is a model id
-  # the downstream target understands.
-  ladder:
-    - ollama/qwen2.5:7b
-    - anthropic/claude-haiku-4-5
-    - anthropic/claude-sonnet-4-6
-    - anthropic/claude-opus-4-7
+  # Top-level paradigm: 'single' (default) for reactive escalation, or
+  # 'chorus' for direct dispatch to a multi-model consensus endpoint.
+  # Per ADR-0021 these are orthogonal answer modes, not stages of the
+  # same process.
+  answer_mode: single
 
-  # Target used by the `max` strategy (single jump).
-  max_model: anthropic/claude-opus-4-7
+  # Adequacy critic (single mode). Skipped entirely in chorus mode.
+  orchestrator:
+    threshold: 0.6
+    grey_band: [0.30, 0.60]
+    weights:
+      refusal: 1.0
+      truncation: 1.0
+      repetition: 1.0
+      empty: 1.0
+      tool_error: 1.0
+      syntax_error: 1.0
+    llm_critic:
+      base_url: http://localhost:11434/v1
+      model: qwen2.5:7b
+      budget_usd: 0.01
 
-  # Set when openclaw-chorus is available. Null → chorus mode falls back to `max`.
-  chorus_endpoint: null
+  # Escalation strategy (single mode + escalate decision). Per
+  # ADR-0021, chorus is no longer an escalation mode — it lives
+  # under its own top-level 'chorus' section below.
+  escalation:
+    # ladder | max
+    mode: ladder
 
-  # Maximum consecutive escalations per request (prevents runaway costs).
-  max_escalation_depth: 2
+    # Ordered chain used by the 'ladder' strategy. Each step is a
+    # model id the downstream target understands.
+    ladder:
+      - ollama/qwen2.5:7b
+      - anthropic/claude-haiku-4-5
+      - anthropic/claude-sonnet-4-6
+      - anthropic/claude-opus-4-7
 
-  critic:
-    # hard_only | hybrid | llm_only
-    strategy: hybrid
-    # Model used by the LLM-critic when strategy is hybrid or llm_only.
-    llm_model: ollama/qwen2.5:7b
-    # Cost ceiling per request for the LLM-critic. Exceeded → hard-signal-only.
-    critic_budget_usd: 0.01
+    # Target used by the 'max' strategy (single jump). Required
+    # when mode is 'max'; ignored in 'ladder' mode.
+    max_model: anthropic/claude-opus-4-7
 
+    # Maximum consecutive escalations per request (prevents runaway
+    # costs). Per ADR-0018, 2 is the recommended default.
+    max_depth: 2
+
+  # Chorus configuration (chorus mode only). Active when
+  # answer_mode is 'chorus'; ignored otherwise. Per ADR-0020 the
+  # dispatch is hard-fail — no silent fallback to single mode.
+  chorus:
+    endpoint: null # set to a chorus endpoint URL, e.g. openclaw-chorus
+    timeout_ms: 90000
+
+  # Transparency layer. The technical default is silent — set
+  # mode: banner below to opt in to user-visible escalation
+  # annotations. See ADR-0022.
   transparency:
-    # banner | silent | card
-    default: banner
+    # banner | silent (card lands with issue #10)
+    mode: banner


### PR DESCRIPTION
The project's user-facing documentation was last meaningfully updated
at 5/15. Since then ladder/max/chorus escalation, the AnswerMode
refactor (ADR-0021), and the transparency banner all landed. The
README still announced 5/15 and the example configs still placed
chorus under escalation.

This PR brings all seven user-facing documents up to the current
state. No code or test changes — purely documentation.

## Files changed

- **README.md** — 9/15 status, AnswerMode section, banner example, opt-in disclaimer.
- **CONTRIBUTING.md** — full rewrite from scaffold to real guide.
- **docs/COMPARISON.md** — real comparison with table + per-project notes.
- **docs/CONFIGURATION.md** — real reference covering all six config types.
- **docs/ARCHITECTURE.md** — real lifecycle diagram + module map.
- **examples/standalone-config.example.yaml** — restructured to post-ADR-0021 shape.
- **examples/openclaw-config.example.json** — same restructuring as YAML variant.

## Verification

`pnpm check` green: 173 tests passed, format/lint/typecheck/build all clean.

## Out of scope

- GitHub repo About field (UI change, separate)
- docs/DESIGN.md (separate planned trim of PROJECT_BRIEF.md)
- Issue #13 and #14 deliverables — those polish whatever state these documents are in at release time