### PR TITLE
feat: transparency card for structured decision context (Issue #10, ADR-0023)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1207,3 +1207,111 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   ADR-0013 (no transparency for streaming responses),
   ADR-0021 (chorus-mode is out of transparency layer scope),
   brief §7 and §14.
+
+## ADR-0023: Transparency card is structured Markdown, locale-aware labels, English values
+
+- **Date:** 2026-04-28
+- **Status:** accepted, implements brief §7
+- **Decision:** Issue #10 adds a third transparency mode, `card`,
+  alongside the existing `banner` and `silent`. The card surfaces
+  the full decision context for a single-mode request: initial
+  model, decision kind plus reason, signals with their
+  confidences, the aggregate score, the optional LLM verdict,
+  the escalation path, and the outcome. The format is a kompakte
+  Markdown list under a distinct marker `[turbocharger card]`,
+  followed by a `---` separator and the original assistant
+  content. Structural labels (`Initial model:`, `Decision:`,
+  ...) are localized for the same `en` and `de` locales the
+  banner supports; values stay English (model IDs, signal
+  categories, decision kinds) to match the `x-turbocharger-*`
+  headers and the ADR vocabulary. The pass + depth=0 suppression
+  rule from the banner applies unchanged: a successful first try
+  produces no card. Cost-delta and time-delta are deliberately
+  not part of the v0.1 card.
+- **Rationale:** The banner conveys "something happened" in one
+  sentence; the card answers "what exactly happened" in seven or
+  eight lines. Operators choose between them based on how much
+  decision context they want their end users to see, not on
+  whether they want transparency at all (that's the
+  silent-vs-not axis). Three reasoning steps lead to the
+  specific shape:
+  - *Why Markdown list and not table.* A Markdown table would
+    render attractively in clients that parse Markdown, but the
+    sidecar cannot assume the client does. A pipe-table in a
+    plain-text view is unreadable. A list works in both.
+  - *Why localize labels but not values.* The labels are user-
+    facing prose that benefits from translation. The values are
+    keys into a small known vocabulary that operators and
+    monitoring tooling already work with in English (`refusal`,
+    `hard_signals`, `pass`). Translating those would diverge the
+    user-visible card from the headers and the structured log,
+    which would be more confusing than helpful.
+  - *Why no cost or time delta in v0.1.* Cost-delta requires
+    per-model pricing data the sidecar does not currently have;
+    fabricating one would be the kind of overclaim the project
+    explicitly avoids. Time-delta is captured in the structured
+    log already and adding it to the card would imply a
+    precision the per-request measurement cannot deliver. Both
+    are candidates for a later issue if real demand materializes.
+- **Alternatives considered:**
+  - *Markdown table.* Rejected per "Why Markdown list" above —
+    plain-text-renderer hostility outweighs the visual
+    compactness for clients that do parse Markdown.
+  - *JSON-in-content surface.* Was the original direction in the
+    `card.ts` stub from Issue #1. Rejected because the card's
+    purpose is end-user readability; clients that want
+    machine-readable decision data already have the
+    `x-turbocharger-*` response headers.
+  - *Shared `[turbocharger]` marker for both banner and card.*
+    Rejected because clients that want to strip transparency
+    annotations need to know whether they are looking at a
+    one-line banner or a multi-line card. Distinct markers
+    (`[turbocharger]` and `[turbocharger card]`) make that
+    decision trivial.
+  - *Localizing values too (e.g. `escalate (harte Signale)`).*
+    Rejected for symmetry with the headers and to keep the
+    grep-ability of the card consistent across locales.
+  - *Showing the LLM verdict's free-form `reason` text.*
+    Considered but rejected: it is the most variable field in
+    the decision surface and including it would make the card
+    unpredictable in length. The structured fields (`verdict`
+    and `confidence`) are more useful at the card level; the
+    free-form reason remains available in the structured log.
+- **Mechanical scope:**
+  - `TransparencyConfig.mode` is widened from `'banner' | 'silent'`
+    to `'banner' | 'silent' | 'card'`.
+  - New module `src/transparency/card.ts` exports `formatCard`,
+    `formatCardPrefix`, `resolveCardLocale`, and `CardLocale`.
+    Pure functions, no I/O. Mirrors the structure of `banner.ts`
+    so future maintenance can rely on familiar shapes.
+  - `runSinglePipeline` gets a second branch in the transparency
+    injection block: when `transparencyConfig.mode === 'card'`,
+    `formatCardPrefix` is called and the same
+    `injectBannerIntoBody` helper (renamed in spirit to "inject
+    string prefix into body" but kept under its original name
+    to minimize the diff) prepends it to `choices[0].message.content`.
+  - `DecisionLogEntry.transparency_mode` already widens
+    automatically — its type is `TransparencyConfig['mode']`.
+  - Two test files: `test/card.test.ts` (~30 unit tests covering
+    locale resolution, all stoppedReasons, both decision kinds
+    with and without LLM verdict, signal filtering, all skipped
+    reasons including streaming-returns-null, both Detail-line
+    behaviours, and `formatCardPrefix`) and
+    `test/pipeline-card.test.ts` (6 integration tests covering
+    card-on-escalate, no-card-on-pass, silent-mode, default-silent,
+    not_attempted-with-no-Path-line, and the German locale).
+- **Consequences for downstream issues:**
+  - Issue #11 (config:schema) needs `'card'` as a third allowed
+    value in the `TransparencyConfig.mode` enum and an example
+    deployment showing card-style configuration.
+  - Issue #12 (per-request header override) gains
+    `X-Turbocharger-Transparency: card` as a valid value
+    alongside `banner` and `silent`.
+  - The README's transparency section already mentioned the card
+    as upcoming; that mention can now point to a real card
+    output example.
+- **Related:** ADR-0007 (transparency-as-design-principle),
+  ADR-0013 (no transparency for streaming responses),
+  ADR-0021 (chorus-mode is out of transparency layer scope),
+  ADR-0022 (transparency banner — the sibling decision this
+  one mirrors structurally), brief §7.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1235,18 +1235,18 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   whether they want transparency at all (that's the
   silent-vs-not axis). Three reasoning steps lead to the
   specific shape:
-  - *Why Markdown list and not table.* A Markdown table would
+  - _Why Markdown list and not table._ A Markdown table would
     render attractively in clients that parse Markdown, but the
     sidecar cannot assume the client does. A pipe-table in a
     plain-text view is unreadable. A list works in both.
-  - *Why localize labels but not values.* The labels are user-
+  - _Why localize labels but not values._ The labels are user-
     facing prose that benefits from translation. The values are
     keys into a small known vocabulary that operators and
     monitoring tooling already work with in English (`refusal`,
     `hard_signals`, `pass`). Translating those would diverge the
     user-visible card from the headers and the structured log,
     which would be more confusing than helpful.
-  - *Why no cost or time delta in v0.1.* Cost-delta requires
+  - _Why no cost or time delta in v0.1._ Cost-delta requires
     per-model pricing data the sidecar does not currently have;
     fabricating one would be the kind of overclaim the project
     explicitly avoids. Time-delta is captured in the structured
@@ -1254,24 +1254,24 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     precision the per-request measurement cannot deliver. Both
     are candidates for a later issue if real demand materializes.
 - **Alternatives considered:**
-  - *Markdown table.* Rejected per "Why Markdown list" above —
+  - _Markdown table._ Rejected per "Why Markdown list" above —
     plain-text-renderer hostility outweighs the visual
     compactness for clients that do parse Markdown.
-  - *JSON-in-content surface.* Was the original direction in the
+  - _JSON-in-content surface._ Was the original direction in the
     `card.ts` stub from Issue #1. Rejected because the card's
     purpose is end-user readability; clients that want
     machine-readable decision data already have the
     `x-turbocharger-*` response headers.
-  - *Shared `[turbocharger]` marker for both banner and card.*
+  - _Shared `[turbocharger]` marker for both banner and card._
     Rejected because clients that want to strip transparency
     annotations need to know whether they are looking at a
     one-line banner or a multi-line card. Distinct markers
     (`[turbocharger]` and `[turbocharger card]`) make that
     decision trivial.
-  - *Localizing values too (e.g. `escalate (harte Signale)`).*
+  - _Localizing values too (e.g. `escalate (harte Signale)`)._
     Rejected for symmetry with the headers and to keep the
     grep-ability of the card consistent across locales.
-  - *Showing the LLM verdict's free-form `reason` text.*
+  - _Showing the LLM verdict's free-form `reason` text._
     Considered but rejected: it is the most variable field in
     the decision surface and including it would make the card
     unpredictable in length. The structured fields (`verdict`

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -41,6 +41,7 @@ import { maxStep } from './escalation/max.js';
 import { dispatchChorus } from './chorus/dispatch.js';
 import { forwardChatCompletion } from './proxy.js';
 import { formatBannerPrefix } from './transparency/banner.js';
+import { formatCardPrefix } from './transparency/card.js';
 import type {
   AnswerMode,
   ChorusConfig,
@@ -282,12 +283,15 @@ export interface PipelineInput {
   readonly escalationConfig?: EscalationConfig;
   /**
    * Optional transparency configuration. When `mode: 'banner'`, the
-   * pipeline prepends a localized banner to the assistant content for
-   * single-mode requests where the orchestrator decided escalate or
-   * skipped-with-reason. When absent or `mode: 'silent'`, the
-   * response body is forwarded unchanged. Per Issue #9 and ADR-0022,
-   * chorus-mode responses are never modified by the transparency
-   * layer regardless of this setting.
+   * pipeline prepends a localized single-line banner to the assistant
+   * content for single-mode requests where the orchestrator decided
+   * escalate or skipped-with-reason. When `mode: 'card'`, the
+   * pipeline instead prepends a structured Markdown card with the
+   * full decision context (initial model, signals, aggregate, path,
+   * outcome). When absent or `mode: 'silent'`, the response body is
+   * forwarded unchanged. Per ADR-0021, chorus-mode responses are
+   * never modified by the transparency layer regardless of this
+   * setting.
    */
   readonly transparencyConfig?: TransparencyConfig;
 }
@@ -546,6 +550,20 @@ async function runSinglePipeline(input: PipelineInput): Promise<SinglePipelineRe
     }
   }
 
+  // Transparency card injection (Issue #10). Same hook point as the
+  // banner; mode is mutually exclusive (transparencyConfig.mode is
+  // either 'banner', 'card', or 'silent'), so at most one of these
+  // two blocks runs per request. The card carries more context
+  // (initial model, signals, aggregate, path, outcome) and uses
+  // `[turbocharger card]` as its marker so clients can distinguish
+  // the two surfaces.
+  if (input.transparencyConfig?.mode === 'card') {
+    const card = formatCardPrefix(currentDecision, trace, parsed.model, parsed.locale);
+    if (card !== null) {
+      currentBodyText = injectBannerIntoBody(currentBodyText, card);
+    }
+  }
+
   const reconstituted = new Response(currentBodyText, {
     status: currentResponse.status,
     statusText: currentResponse.statusText,
@@ -580,12 +598,18 @@ function buildOrchestratorInput(
 }
 
 /**
- * Prepend the transparency banner to `choices[0].message.content` of
- * an OpenAI-compatible chat completion JSON body. Returns the modified
- * body as a string.
+ * Prepend a transparency prefix (banner or card) to
+ * `choices[0].message.content` of an OpenAI-compatible chat
+ * completion JSON body. Returns the modified body as a string.
+ *
+ * The function is shape-agnostic about the prefix — banner and
+ * card both produce a string that, when prepended, yields the
+ * intended Markdown-style annotation. Issue #9 introduced this
+ * helper for the banner; Issue #10 reuses it unchanged for the
+ * card by passing a longer prefix string.
  *
  * If the body is malformed JSON or the choices array is missing, the
- * banner cannot be safely injected and the original body is returned
+ * prefix cannot be safely injected and the original body is returned
  * unchanged. The pipeline has already established earlier that the
  * downstream content-type is `application/json` and the orchestrator
  * could parse the response, so a malformed body here would be unusual,

--- a/src/transparency/card.ts
+++ b/src/transparency/card.ts
@@ -1,6 +1,254 @@
-// TODO(issue #10): Card mode (opt-in).
-// Structured block showing: initial model + discarded response, critic verdict
-// + confidence, final model, cost delta vs. starting fresh with final model,
-// time delta.
+// Transparency card (Issue #10).
+//
+// The card is a structured-Markdown counterpart to the single-line
+// banner from Issue #9. Where the banner conveys "something happened"
+// in one sentence, the card surfaces the full decision context:
+// which model the request started with, what the orchestrator
+// decided and why, which signals fired with what confidence, the
+// aggregate score, the escalation path, and the outcome.
+//
+// Like the banner, the card is opt-in (technical default is
+// `silent`) and only emits in single-mode responses — chorus-mode
+// responses are exempt per ADR-0021. Streaming is exempt per
+// ADR-0013 since the orchestrator does not run there in the first
+// place.
+//
+// Format (English variant, escalation that succeeded on a re-query):
+//
+//   [turbocharger card]
+//   - Initial model: weak-model
+//   - Decision: escalate (hard_signals)
+//   - Signals: refusal (0.92)
+//   - Aggregate: 0.853
+//   - Path: weak-model → mid-model
+//   - Outcome: passed at depth 1
+//
+//   ---
+//
+//   <original assistant content>
+//
+// Design notes:
+//
+//   - The marker `[turbocharger card]` is distinct from the banner's
+//     `[turbocharger]`. Clients that strip transparency annotations
+//     can match each marker independently.
+//   - Structural labels (`Initial model:`, `Decision:`, ...) are
+//     localized — `en` and `de`. Values stay English (model IDs,
+//     signal categories like `refusal`, decision kinds like `pass`).
+//     These match the `x-turbocharger-*` headers and ADR vocabulary;
+//     localizing them would diverge user-facing text from the
+//     machine-readable surface.
+//   - Pass + depth=0 emits no card, matching the banner suppression
+//     rule. The card is for "something interesting happened"; a
+//     successful first try is not interesting.
+//   - LLM-verdict information is shown when present (one extra line
+//     with verdict + confidence). The verdict's free-form `reason`
+//     text is not shown — it would be the most variable field and
+//     the operator opted into a structured surface, not free text.
+//   - Cost-delta and time-delta are deliberately out of scope for
+//     v0.1 of the card. Cost delta requires per-model pricing data
+//     the sidecar does not have today; time delta is captured in
+//     the structured log already and adding it here would imply a
+//     precision the card cannot deliver. Both are candidates for
+//     a later issue.
 
-export {};
+import type { EscalationTrace, OrchestratorDecision, Signal } from '../types.js';
+
+export type CardLocale = 'en' | 'de';
+
+const CARD_MARKER = '[turbocharger card]';
+
+/**
+ * Resolve a BCP-47 locale tag to one of the supported card locales.
+ * Mirrors the banner's resolveBannerLocale: `de*` → `de`, everything
+ * else → `en`.
+ */
+export function resolveCardLocale(locale: string | undefined): CardLocale {
+  if (locale === undefined || locale.length === 0) return 'en';
+  const lower = locale.toLowerCase();
+  if (lower === 'de' || lower.startsWith('de-') || lower.startsWith('de_')) return 'de';
+  return 'en';
+}
+
+/**
+ * Produce the card text (without trailing separator or blank line)
+ * for a given decision and trace, or `null` if no card should be
+ * emitted (pass + depth=0, or skipped with a reason that has no
+ * card mapping).
+ */
+export function formatCard(
+  decision: OrchestratorDecision,
+  trace: EscalationTrace,
+  initialModel: string,
+  locale: string | undefined,
+): string | null {
+  const lang = resolveCardLocale(locale);
+  const labels = LABELS[lang];
+
+  // Suppress for pass + depth=0 (consistent with banner).
+  if (decision.kind === 'pass' && trace.depth === 0) return null;
+
+  // Skipped decisions: only emit for skipped reasons that have a
+  // user-visible mapping. Streaming-skipped never reaches this
+  // function (orchestrator does not run for streaming) but we list
+  // it explicitly via the LABELS table for completeness.
+  if (decision.kind === 'skipped') {
+    const skipText = labels.skipReasons[decision.reason];
+    if (skipText === undefined) return null;
+    const lines = [
+      CARD_MARKER,
+      `- ${labels.initialModel}: ${initialModel}`,
+      `- ${labels.decision}: skipped (${skipText})`,
+    ];
+    if (decision.detail !== undefined && decision.detail.length > 0) {
+      lines.push(`- ${labels.detail}: ${decision.detail}`);
+    }
+    return lines.join('\n');
+  }
+
+  // Pass + depth>0 (re-query produced a passing answer) and escalate
+  // both share the same field set: initial model, decision, signals
+  // (when present), aggregate, optional verdict, path, outcome. The
+  // decision-line wording differs slightly to make the success vs
+  // open-ended escalation distinction visible.
+  const lines: string[] = [CARD_MARKER];
+  lines.push(`- ${labels.initialModel}: ${initialModel}`);
+
+  if (decision.kind === 'pass') {
+    lines.push(`- ${labels.decision}: ${labels.passAfterEscalation}`);
+  } else {
+    // escalate
+    lines.push(`- ${labels.decision}: escalate (${decision.reason})`);
+  }
+
+  if (decision.signals.length > 0) {
+    const nonZero = decision.signals.filter((s) => s.confidence > 0);
+    if (nonZero.length > 0) {
+      lines.push(`- ${labels.signals}: ${formatSignals(nonZero)}`);
+    }
+  }
+
+  lines.push(`- ${labels.aggregate}: ${decision.aggregate.toFixed(3)}`);
+
+  if (decision.verdict !== undefined) {
+    lines.push(
+      `- ${labels.llmVerdict}: ${decision.verdict.verdict} (${decision.verdict.confidence.toFixed(2)})`,
+    );
+  }
+
+  if (trace.path.length > 0) {
+    lines.push(`- ${labels.path}: ${[initialModel, ...trace.path].join(' → ')}`);
+  }
+
+  lines.push(`- ${labels.outcome}: ${formatOutcome(trace, labels)}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Convenience for the pipeline: returns the card text plus the
+ * `---` separator and trailing blank line, ready to be prepended
+ * to assistant content. Returns `null` when no card should be
+ * emitted.
+ */
+export function formatCardPrefix(
+  decision: OrchestratorDecision,
+  trace: EscalationTrace,
+  initialModel: string,
+  locale: string | undefined,
+): string | null {
+  const card = formatCard(decision, trace, initialModel, locale);
+  if (card === null) return null;
+  return `${card}\n\n---\n\n`;
+}
+
+function formatSignals(signals: readonly Signal[]): string {
+  return signals.map((s) => `${s.category} (${s.confidence.toFixed(2)})`).join(', ');
+}
+
+function formatOutcome(trace: EscalationTrace, labels: CardLabels): string {
+  switch (trace.stoppedReason) {
+    case 'passed':
+      return labels.outcomePassedAtDepth.replace('{depth}', String(trace.depth));
+    case 'max_depth_reached':
+      return labels.outcomeMaxDepthReached;
+    case 'ladder_exhausted':
+      return labels.outcomeLadderExhausted;
+    case 'model_not_on_ladder':
+      return labels.outcomeModelNotOnLadder;
+    case 'max_model_not_set':
+      return labels.outcomeMaxModelNotSet;
+    case 'not_attempted':
+      return labels.outcomeNotAttempted;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Label tables
+// ---------------------------------------------------------------------------
+
+interface CardLabels {
+  readonly initialModel: string;
+  readonly decision: string;
+  readonly signals: string;
+  readonly aggregate: string;
+  readonly llmVerdict: string;
+  readonly path: string;
+  readonly outcome: string;
+  readonly detail: string;
+  readonly passAfterEscalation: string;
+  readonly outcomePassedAtDepth: string;
+  readonly outcomeMaxDepthReached: string;
+  readonly outcomeLadderExhausted: string;
+  readonly outcomeModelNotOnLadder: string;
+  readonly outcomeMaxModelNotSet: string;
+  readonly outcomeNotAttempted: string;
+  readonly skipReasons: Partial<
+    Record<NonNullable<Extract<OrchestratorDecision, { kind: 'skipped' }>['reason']>, string>
+  >;
+}
+
+const LABELS: Record<CardLocale, CardLabels> = {
+  en: {
+    initialModel: 'Initial model',
+    decision: 'Decision',
+    signals: 'Signals',
+    aggregate: 'Aggregate',
+    llmVerdict: 'LLM verdict',
+    path: 'Path',
+    outcome: 'Outcome',
+    detail: 'Detail',
+    passAfterEscalation: 'pass (after escalation)',
+    outcomePassedAtDepth: 'passed at depth {depth}',
+    outcomeMaxDepthReached: 'stopped after reaching max depth',
+    outcomeLadderExhausted: 'stopped after exhausting the ladder',
+    outcomeModelNotOnLadder: 'stopped because no stronger model is configured',
+    outcomeMaxModelNotSet: 'stopped because max-mode has no target model',
+    outcomeNotAttempted: 'no escalation attempted (disabled)',
+    skipReasons: {
+      non_ok_status: 'non_ok_status',
+      non_json_content_type: 'non_json_content_type',
+    },
+  },
+  de: {
+    initialModel: 'Initiales Modell',
+    decision: 'Entscheidung',
+    signals: 'Signale',
+    aggregate: 'Aggregat',
+    llmVerdict: 'LLM-Verdict',
+    path: 'Pfad',
+    outcome: 'Ergebnis',
+    detail: 'Detail',
+    passAfterEscalation: 'pass (nach Eskalation)',
+    outcomePassedAtDepth: 'passed bei Tiefe {depth}',
+    outcomeMaxDepthReached: 'gestoppt nach Erreichen der Max-Tiefe',
+    outcomeLadderExhausted: 'gestoppt nach Aufbrauch der Ladder',
+    outcomeModelNotOnLadder: 'gestoppt, weil kein stärkeres Modell konfiguriert ist',
+    outcomeMaxModelNotSet: 'gestoppt, weil Max-Mode kein Zielmodell hat',
+    outcomeNotAttempted: 'keine Eskalation versucht (deaktiviert)',
+    skipReasons: {
+      non_ok_status: 'non_ok_status',
+      non_json_content_type: 'non_json_content_type',
+    },
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -510,10 +510,18 @@ export interface ChorusTrace {
  * deliberate choice: response-body mutation is invasive and should
  * only happen when the operator has consciously chosen it.
  *
- * Issue #10 will add `mode: 'card'` for a structured JSON-in-content
- * surface as a third option. Chorus-mode responses are out of scope
- * for the transparency layer per ADR-0021.
+ * Issue #10 adds `mode: 'card'`: a structured Markdown block — the
+ * `[turbocharger card]` marker, a list of fields describing the
+ * decision (initial model, decision kind + reason, signals,
+ * aggregate score, escalation path, outcome), a `---` separator,
+ * and the original assistant content. The card surfaces more
+ * detail than the single-line banner for operators who want
+ * end users to see the full decision context. Like the banner
+ * it is opt-in; the technical default remains `silent`.
+ *
+ * Chorus-mode responses are out of scope for the transparency layer
+ * per ADR-0021.
  */
 export interface TransparencyConfig {
-  readonly mode: 'banner' | 'silent';
+  readonly mode: 'banner' | 'silent' | 'card';
 }

--- a/test/card.test.ts
+++ b/test/card.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatCard,
+  formatCardPrefix,
+  resolveCardLocale,
+  type CardLocale,
+} from '../src/transparency/card.js';
+import type { EscalationTrace, OrchestratorDecision, Signal } from '../src/types.js';
+
+function trace(
+  stoppedReason: EscalationTrace['stoppedReason'],
+  depth = 0,
+  path: readonly string[] = [],
+): EscalationTrace {
+  return { path, stoppedReason, depth };
+}
+
+const REFUSAL_SIGNAL: Signal = {
+  category: 'refusal',
+  confidence: 0.92,
+  reason: 'matched refusal phrase',
+};
+
+const TRUNCATION_SIGNAL: Signal = {
+  category: 'truncation',
+  confidence: 0.85,
+  reason: 'finish_reason=length',
+};
+
+const ZERO_SIGNAL: Signal = {
+  category: 'empty',
+  confidence: 0,
+  reason: 'no evidence',
+};
+
+const PASS_DECISION: OrchestratorDecision = {
+  kind: 'pass',
+  signals: [],
+  aggregate: 0,
+};
+
+const ESCALATE_DECISION_HARD: OrchestratorDecision = {
+  kind: 'escalate',
+  reason: 'hard_signals',
+  signals: [REFUSAL_SIGNAL],
+  aggregate: 0.853,
+};
+
+const ESCALATE_DECISION_LLM: OrchestratorDecision = {
+  kind: 'escalate',
+  reason: 'llm_verdict',
+  signals: [],
+  aggregate: 0.45,
+  verdict: { verdict: 'fail', confidence: 0.78, reason: 'answer is incomplete' },
+};
+
+describe('resolveCardLocale', () => {
+  it.each<[string | undefined, CardLocale]>([
+    [undefined, 'en'],
+    ['', 'en'],
+    ['en', 'en'],
+    ['en-US', 'en'],
+    ['fr', 'en'],
+    ['fr-FR', 'en'],
+    ['de', 'de'],
+    ['de-DE', 'de'],
+    ['de-AT', 'de'],
+    ['de-CH', 'de'],
+    ['DE-DE', 'de'],
+    ['de_DE', 'de'],
+  ])('resolves %s to %s', (input, expected) => {
+    expect(resolveCardLocale(input)).toBe(expected);
+  });
+});
+
+describe('formatCard — pass decisions, depth-aware', () => {
+  it.each<string | undefined>(['en', 'de', undefined])(
+    'returns null for pass with depth=0 in locale %s',
+    (locale) => {
+      expect(formatCard(PASS_DECISION, trace('passed'), 'weak-model', locale)).toBeNull();
+      expect(formatCardPrefix(PASS_DECISION, trace('passed'), 'weak-model', locale)).toBeNull();
+    },
+  );
+
+  it('emits a card for pass with depth>0 (re-query produced a passing answer) — English', () => {
+    const card = formatCard(
+      PASS_DECISION,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'en',
+    );
+    expect(card).toContain('[turbocharger card]');
+    expect(card).toContain('Initial model: weak-model');
+    expect(card).toContain('Decision: pass (after escalation)');
+    expect(card).toContain('Path: weak-model → mid-model');
+    expect(card).toContain('Outcome: passed at depth 1');
+  });
+
+  it('emits a card for pass with depth>0 — German', () => {
+    const card = formatCard(
+      PASS_DECISION,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'de',
+    );
+    expect(card).toContain('[turbocharger card]');
+    expect(card).toContain('Initiales Modell: weak-model');
+    expect(card).toContain('Entscheidung: pass (nach Eskalation)');
+    expect(card).toContain('Pfad: weak-model → mid-model');
+    expect(card).toContain('Ergebnis: passed bei Tiefe 1');
+  });
+});
+
+describe('formatCard — escalate (hard_signals)', () => {
+  it('emits a full card with all fields — English', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'en',
+    );
+    expect(card).toBe(
+      [
+        '[turbocharger card]',
+        '- Initial model: weak-model',
+        '- Decision: escalate (hard_signals)',
+        '- Signals: refusal (0.92)',
+        '- Aggregate: 0.853',
+        '- Path: weak-model → mid-model',
+        '- Outcome: passed at depth 1',
+      ].join('\n'),
+    );
+  });
+
+  it('emits a full card — German', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'de',
+    );
+    expect(card).toBe(
+      [
+        '[turbocharger card]',
+        '- Initiales Modell: weak-model',
+        '- Entscheidung: escalate (hard_signals)',
+        '- Signale: refusal (0.92)',
+        '- Aggregat: 0.853',
+        '- Pfad: weak-model → mid-model',
+        '- Ergebnis: passed bei Tiefe 1',
+      ].join('\n'),
+    );
+  });
+
+  it('lists multiple signals comma-separated', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'escalate',
+      reason: 'hard_signals',
+      signals: [REFUSAL_SIGNAL, TRUNCATION_SIGNAL],
+      aggregate: 0.95,
+    };
+    const card = formatCard(decision, trace('passed', 1, ['mid-model']), 'weak-model', 'en');
+    expect(card).toContain('Signals: refusal (0.92), truncation (0.85)');
+  });
+
+  it('omits signals with confidence === 0 from the list', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'escalate',
+      reason: 'hard_signals',
+      signals: [REFUSAL_SIGNAL, ZERO_SIGNAL],
+      aggregate: 0.92,
+    };
+    const card = formatCard(decision, trace('passed', 1, ['mid-model']), 'weak-model', 'en');
+    expect(card).toContain('Signals: refusal (0.92)');
+    expect(card).not.toContain('empty');
+  });
+
+  it('omits the Signals line entirely when all signals have confidence 0', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'escalate',
+      reason: 'hard_signals',
+      signals: [ZERO_SIGNAL],
+      aggregate: 0.0,
+    };
+    const card = formatCard(decision, trace('passed', 1, ['mid-model']), 'weak-model', 'en');
+    expect(card).not.toContain('Signals');
+    expect(card).not.toContain('Signale');
+  });
+
+  it('omits the Signals line when signals is empty', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'escalate',
+      reason: 'hard_signals',
+      signals: [],
+      aggregate: 0.0,
+    };
+    const card = formatCard(decision, trace('passed', 1, ['mid-model']), 'weak-model', 'en');
+    expect(card).not.toContain('Signals');
+  });
+});
+
+describe('formatCard — escalate (llm_verdict)', () => {
+  it('includes an LLM verdict line when verdict is present — English', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_LLM,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'en',
+    );
+    expect(card).toContain('Decision: escalate (llm_verdict)');
+    expect(card).toContain('LLM verdict: fail (0.78)');
+  });
+
+  it('includes the LLM verdict line in German', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_LLM,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'de',
+    );
+    expect(card).toContain('LLM-Verdict: fail (0.78)');
+  });
+
+  it('does not include the LLM verdict line when verdict is absent', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'en',
+    );
+    expect(card).not.toContain('LLM verdict');
+    expect(card).not.toContain('LLM-Verdict');
+  });
+});
+
+describe('formatCard — outcomes', () => {
+  it.each<[EscalationTrace['stoppedReason'], string]>([
+    ['max_depth_reached', 'stopped after reaching max depth'],
+    ['ladder_exhausted', 'stopped after exhausting the ladder'],
+    ['model_not_on_ladder', 'stopped because no stronger model is configured'],
+    ['max_model_not_set', 'stopped because max-mode has no target model'],
+    ['not_attempted', 'no escalation attempted (disabled)'],
+  ])('renders outcome for %s in English', (stoppedReason, expectedText) => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace(stoppedReason, 0, []),
+      'weak-model',
+      'en',
+    );
+    expect(card).toContain(`Outcome: ${expectedText}`);
+  });
+
+  it.each<[EscalationTrace['stoppedReason'], string]>([
+    ['max_depth_reached', 'gestoppt nach Erreichen der Max-Tiefe'],
+    ['ladder_exhausted', 'gestoppt nach Aufbrauch der Ladder'],
+    ['model_not_on_ladder', 'gestoppt, weil kein stärkeres Modell konfiguriert ist'],
+    ['max_model_not_set', 'gestoppt, weil Max-Mode kein Zielmodell hat'],
+    ['not_attempted', 'keine Eskalation versucht (deaktiviert)'],
+  ])('renders outcome for %s in German', (stoppedReason, expectedText) => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace(stoppedReason, 0, []),
+      'weak-model',
+      'de',
+    );
+    expect(card).toContain(`Ergebnis: ${expectedText}`);
+  });
+
+  it('omits the Path line when path is empty (e.g. not_attempted)', () => {
+    const card = formatCard(
+      ESCALATE_DECISION_HARD,
+      trace('not_attempted', 0, []),
+      'weak-model',
+      'en',
+    );
+    expect(card).not.toContain('Path:');
+    expect(card).toContain('Outcome: no escalation attempted (disabled)');
+  });
+});
+
+describe('formatCard — skipped decisions', () => {
+  it('emits a short card for non_ok_status — English', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_ok_status',
+      detail: '502 Bad Gateway',
+    };
+    const card = formatCard(decision, trace('not_attempted'), 'weak-model', 'en');
+    expect(card).toBe(
+      [
+        '[turbocharger card]',
+        '- Initial model: weak-model',
+        '- Decision: skipped (non_ok_status)',
+        '- Detail: 502 Bad Gateway',
+      ].join('\n'),
+    );
+  });
+
+  it('emits a short card for non_json_content_type — German', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_json_content_type',
+    };
+    const card = formatCard(decision, trace('not_attempted'), 'weak-model', 'de');
+    expect(card).toBe(
+      [
+        '[turbocharger card]',
+        '- Initiales Modell: weak-model',
+        '- Entscheidung: skipped (non_json_content_type)',
+      ].join('\n'),
+    );
+  });
+
+  it('returns null for streaming-skipped (no card mapping)', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'streaming',
+    };
+    expect(formatCard(decision, trace('not_attempted'), 'weak-model', 'en')).toBeNull();
+  });
+
+  it('omits the Detail line when detail is undefined', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_ok_status',
+    };
+    const card = formatCard(decision, trace('not_attempted'), 'weak-model', 'en');
+    expect(card).not.toContain('Detail');
+  });
+
+  it('omits the Detail line when detail is the empty string', () => {
+    const decision: OrchestratorDecision = {
+      kind: 'skipped',
+      reason: 'non_ok_status',
+      detail: '',
+    };
+    const card = formatCard(decision, trace('not_attempted'), 'weak-model', 'en');
+    expect(card).not.toContain('Detail');
+  });
+});
+
+describe('formatCardPrefix', () => {
+  it('appends a separator and trailing blank line', () => {
+    const prefix = formatCardPrefix(
+      ESCALATE_DECISION_HARD,
+      trace('passed', 1, ['mid-model']),
+      'weak-model',
+      'en',
+    );
+    expect(prefix).not.toBeNull();
+    expect(prefix!.endsWith('\n\n---\n\n')).toBe(true);
+  });
+
+  it('returns null for pass + depth=0', () => {
+    expect(formatCardPrefix(PASS_DECISION, trace('passed'), 'weak-model', 'en')).toBeNull();
+  });
+});

--- a/test/card.test.ts
+++ b/test/card.test.ts
@@ -84,12 +84,7 @@ describe('formatCard — pass decisions, depth-aware', () => {
   );
 
   it('emits a card for pass with depth>0 (re-query produced a passing answer) — English', () => {
-    const card = formatCard(
-      PASS_DECISION,
-      trace('passed', 1, ['mid-model']),
-      'weak-model',
-      'en',
-    );
+    const card = formatCard(PASS_DECISION, trace('passed', 1, ['mid-model']), 'weak-model', 'en');
     expect(card).toContain('[turbocharger card]');
     expect(card).toContain('Initial model: weak-model');
     expect(card).toContain('Decision: pass (after escalation)');
@@ -98,12 +93,7 @@ describe('formatCard — pass decisions, depth-aware', () => {
   });
 
   it('emits a card for pass with depth>0 — German', () => {
-    const card = formatCard(
-      PASS_DECISION,
-      trace('passed', 1, ['mid-model']),
-      'weak-model',
-      'de',
-    );
+    const card = formatCard(PASS_DECISION, trace('passed', 1, ['mid-model']), 'weak-model', 'de');
     expect(card).toContain('[turbocharger card]');
     expect(card).toContain('Initiales Modell: weak-model');
     expect(card).toContain('Entscheidung: pass (nach Eskalation)');

--- a/test/pipeline-card.test.ts
+++ b/test/pipeline-card.test.ts
@@ -312,7 +312,11 @@ describe('pipeline transparency (card)', () => {
       const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
       res.writeHead(200, { 'Content-Type': 'application/json' });
       if (parsed.model === 'weak-model') {
-        res.end(buildChatCompletionBody('Tut mir leid, ich kann dabei nicht helfen.'));
+        // Refusal phrasing in English so the en-pattern fallback catches it.
+        // The hard-signal detector resolves locales by exact key, so 'de-DE'
+        // misses the 'de' bucket and only the en-fallback patterns run.
+        // The banner DE test takes the same approach.
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
       } else {
         res.end(
           buildChatCompletionBody(

--- a/test/pipeline-card.test.ts
+++ b/test/pipeline-card.test.ts
@@ -1,0 +1,343 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
+import type {
+  EscalationConfig,
+  OrchestratorConfig,
+  SignalWeights,
+  TransparencyConfig,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirror test/pipeline-banner.test.ts)
+// ---------------------------------------------------------------------------
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  readonly baseUrl: string;
+  setHandler(handler: MockHandler): void;
+  bodies(): readonly Buffer[];
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+  const seen: Buffer[] = [];
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      seen.push(body);
+      Promise.resolve(handler(req, res, body)).catch((err: unknown) => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end(`mock-error: ${String(err)}`);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}/v1`,
+    setHandler(h) {
+      handler = h;
+    },
+    bodies() {
+      return seen;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+const DEFAULT_WEIGHTS: SignalWeights = {
+  refusal: 1,
+  truncation: 1,
+  repetition: 1,
+  empty: 1,
+  tool_error: 1,
+  syntax_error: 1,
+};
+
+function makeOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    threshold: 0.6,
+    weights: DEFAULT_WEIGHTS,
+    greyBand: [0.3, 0.6] as const,
+    ...overrides,
+  };
+}
+
+function makeEscalationConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
+  return {
+    mode: 'ladder',
+    ladder: ['weak-model', 'mid-model', 'strong-model'],
+    maxDepth: 2,
+    ...overrides,
+  };
+}
+
+function buildChatCompletionBody(content: string): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: 'stop',
+      },
+    ],
+  });
+}
+
+function extractContent(bodyText: string): string {
+  const obj = JSON.parse(bodyText) as {
+    choices: ReadonlyArray<{ message: { content: string } }>;
+  };
+  return obj.choices[0]!.message.content;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('pipeline transparency (card)', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  function startSidecar(transparencyConfig?: TransparencyConfig): void {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig(),
+        ...(transparencyConfig !== undefined ? { transparencyConfig } : {}),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  }
+
+  it('prepends a card to the assistant content when escalation succeeded', async () => {
+    startSidecar({ mode: 'card' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger card]')).toBe(true);
+    expect(content).toContain('Initial model: weak-model');
+    expect(content).toContain('Decision: pass (after escalation)');
+    expect(content).toContain('Path: weak-model → mid-model');
+    expect(content).toContain('Outcome: passed at depth 1');
+    expect(content).toContain('\n\n---\n\n');
+    // Original content is preserved AFTER the card.
+    expect(content).toContain('clear, complete, helpful answer');
+
+    expect(logs[0]?.transparency_mode).toBe('card');
+  });
+
+  it('does not prepend a card when the first response passes', async () => {
+    startSidecar({ mode: 'card' });
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Explain it briefly.' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger')).toBe(false);
+    expect(content.startsWith('Here is a clear')).toBe(true);
+  });
+
+  it('does not prepend a card when transparency mode is silent', async () => {
+    startSidecar({ mode: 'silent' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(buildChatCompletionBody('A complete and useful answer with relevant details.'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger')).toBe(false);
+  });
+
+  it('does not prepend a card when no transparencyConfig is configured (silent default)', async () => {
+    startSidecar();
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(buildChatCompletionBody('A complete and useful answer with relevant details.'));
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger')).toBe(false);
+    expect(logs[0]?.transparency_mode).toBeUndefined();
+  });
+
+  it('emits a card with not_attempted outcome when escalation is disabled (maxDepth=0)', async () => {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig({ maxDepth: 0 }),
+        transparencyConfig: { mode: 'card' },
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+
+    mock.setHandler((_req, res, _body) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Please help.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger card]')).toBe(true);
+    expect(content).toContain('Decision: escalate (hard_signals)');
+    expect(content).toContain('Outcome: no escalation attempted (disabled)');
+    // Path line is omitted because path is empty.
+    expect(content).not.toContain('\n- Path:');
+  });
+
+  it('honors Accept-Language for German cards', async () => {
+    startSidecar({ mode: 'card' });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody('Tut mir leid, ich kann dabei nicht helfen.'));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Hier ist eine klare und vollständige Antwort mit konkreten Details und Kontext.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Language': 'de-DE,de;q=0.9,en;q=0.7',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'Bitte hilf mir.' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content.startsWith('[turbocharger card]')).toBe(true);
+    expect(content).toContain('Initiales Modell: weak-model');
+    expect(content).toContain('Pfad: weak-model → mid-model');
+    expect(content).toContain('Ergebnis: passed bei Tiefe 1');
+  });
+});


### PR DESCRIPTION
Closes #10. Adds the third transparency mode — `card` — alongside
the existing `banner` and `silent`. ADR-0023 records the design.

## What

Where the banner conveys "something happened" in one sentence, the
card surfaces the full decision context: initial model, decision
kind plus reason, signals with their confidences, the aggregate
score, the optional LLM verdict, the escalation path, and the
outcome.