### PR TITLE
feat: Zod-validated config loader with YAML/JSON file support (Issue #11, ADR-0024)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1363,7 +1363,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     awkward because you cannot set env vars from inside an
     immutable image.
   - _Hard rename to `TURBOCHARGER_`_ avoids namespace collisions
-    (`TURBO_PORT` could plausibly belong to other tooling). The
+(`TURBO_PORT` could plausibly belong to other tooling). The
     previous prefix shipped only in pre-MVP code; the cost of
     breaking is paid by exactly one user (the maintainer).
 - **Alternatives considered:**
@@ -1382,7 +1382,7 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     Operators want a structured artifact they can review.
   - _File overrides env._ Rejected per "Rationale" above —
     incompatible with immutable container images.
-  - _Deprecate-and-warn the `TURBO_` prefix._ Rejected: the
+  - _Deprecate-and-warn the `TURBO_` prefix.\_ Rejected: the
     deprecation window adds permanent code complexity (alias
     table, warning emission, eventual removal) for zero
     deployed users. Hard rename is honest.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1348,45 +1348,45 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
 - **Rationale:** The four sub-decisions all reflect the same
   underlying value: the loader has to be obviously correct from
   the operator's perspective. That breaks down into:
-  - *Types-first* keeps the mental model "the code defines the
+  - _Types-first_ keeps the mental model "the code defines the
     shape; the schema validates against it" rather than the
     reverse, which would propagate Zod's quirks through the
     project. The compile-time equivalence guard means nobody
     silently forgets to update the schema after editing a type.
-  - *YAML and JSON* is what operators expect; insisting on one
+  - _YAML and JSON_ is what operators expect; insisting on one
     creates friction. Both parsers are mature and the file
     format is the operator's choice, not the loader's.
-  - *Env-overrides-file* matches 12-factor expectations and lets
+  - _Env-overrides-file_ matches 12-factor expectations and lets
     deployments use a checked-in config-file baseline plus
     per-environment env overrides. The reverse precedence
     (file overrides env) would make container deployments
     awkward because you cannot set env vars from inside an
     immutable image.
-  - *Hard rename to `TURBOCHARGER_`* avoids namespace collisions
+  - _Hard rename to `TURBOCHARGER_`_ avoids namespace collisions
     (`TURBO_PORT` could plausibly belong to other tooling). The
     previous prefix shipped only in pre-MVP code; the cost of
     breaking is paid by exactly one user (the maintainer).
 - **Alternatives considered:**
-  - *Zod as source of truth.* Rejected: the existing
+  - _Zod as source of truth._ Rejected: the existing
     `src/types.ts` is the central type surface that every module
     depends on; rewriting all consumers to import from
     `z.infer<>` would dwarf the actual loader work and risk the
     rest of the MVP timeline.
-  - *Single file format (YAML only).* Rejected: JSON is
+  - _Single file format (YAML only)._ Rejected: JSON is
     machine-friendly for tooling, YAML is human-friendly for
     hand-edit. Supporting both costs ~30 lines and removes the
     operator's "wait, which format does this thing want" check.
-  - *Per-step env vars only, no config file.* Rejected: a
+  - _Per-step env vars only, no config file._ Rejected: a
     20-field deployment with weights, ladder, chorus endpoint,
     and transparency mode is unreadable as a flat env var dump.
     Operators want a structured artifact they can review.
-  - *File overrides env.* Rejected per "Rationale" above —
+  - _File overrides env._ Rejected per "Rationale" above —
     incompatible with immutable container images.
-  - *Deprecate-and-warn the `TURBO_` prefix.* Rejected: the
+  - _Deprecate-and-warn the `TURBO_` prefix._ Rejected: the
     deprecation window adds permanent code complexity (alias
     table, warning emission, eventual removal) for zero
     deployed users. Hard rename is honest.
-  - *Lenient unknown-field handling.* Rejected: silent
+  - _Lenient unknown-field handling._ Rejected: silent
     acceptance of typos like `transparancy.mode` is exactly the
     "no silent fallbacks" failure mode the brief calls out.
     `.strict()` on every Zod object means a typo fails loudly.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1315,3 +1315,125 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   ADR-0021 (chorus-mode is out of transparency layer scope),
   ADR-0022 (transparency banner — the sibling decision this
   one mirrors structurally), brief §7.
+
+## ADR-0024: Configuration is YAML/JSON, env-overrides-file, Zod-validated, types-first
+
+- **Date:** 2026-04-29
+- **Status:** accepted, implements brief §5 and §8
+- **Decision:** Issue #11 introduces a full configuration loader.
+  Four sub-decisions are bundled into a single ADR because they
+  describe one cohesive system:
+  1. **Source of truth.** TypeScript interfaces in `src/types.ts`
+     remain authoritative. Zod schemas in `src/config/schema.ts`
+     are written so that `z.infer<typeof X>` is structurally
+     assignable to the corresponding hand-written interface; a
+     compile-time guard in the same file flags drift.
+  2. **File formats.** YAML and JSON are both accepted. File
+     extension decides parser (`.yaml`/`.yml` → YAML, `.json` →
+     JSON). The `yaml` npm package is the third runtime
+     dependency, well within the brief's "fewer than five"
+     ceiling.
+  3. **Source precedence.** Environment variables override file
+     values; file values override the hard-coded `port = 11435`
+     default. The merge is deep: an orchestrator block in a YAML
+     plus a `TURBOCHARGER_ORCHESTRATOR__THRESHOLD` env override
+     produces a single merged orchestrator config.
+  4. **Env-var convention.** Prefix is `TURBOCHARGER_`. Nested
+     fields use `__` (double underscore) as path separator;
+     primitive arrays use `,` as element separator. The legacy
+     `TURBO_` prefix from Issue #2 is removed in this commit (a
+     hard rename — no alias, no deprecation period). Pre-v0.1
+     tolerates breaking changes; carrying an alias forever is
+     more confusing than fixing it now.
+- **Rationale:** The four sub-decisions all reflect the same
+  underlying value: the loader has to be obviously correct from
+  the operator's perspective. That breaks down into:
+  - *Types-first* keeps the mental model "the code defines the
+    shape; the schema validates against it" rather than the
+    reverse, which would propagate Zod's quirks through the
+    project. The compile-time equivalence guard means nobody
+    silently forgets to update the schema after editing a type.
+  - *YAML and JSON* is what operators expect; insisting on one
+    creates friction. Both parsers are mature and the file
+    format is the operator's choice, not the loader's.
+  - *Env-overrides-file* matches 12-factor expectations and lets
+    deployments use a checked-in config-file baseline plus
+    per-environment env overrides. The reverse precedence
+    (file overrides env) would make container deployments
+    awkward because you cannot set env vars from inside an
+    immutable image.
+  - *Hard rename to `TURBOCHARGER_`* avoids namespace collisions
+    (`TURBO_PORT` could plausibly belong to other tooling). The
+    previous prefix shipped only in pre-MVP code; the cost of
+    breaking is paid by exactly one user (the maintainer).
+- **Alternatives considered:**
+  - *Zod as source of truth.* Rejected: the existing
+    `src/types.ts` is the central type surface that every module
+    depends on; rewriting all consumers to import from
+    `z.infer<>` would dwarf the actual loader work and risk the
+    rest of the MVP timeline.
+  - *Single file format (YAML only).* Rejected: JSON is
+    machine-friendly for tooling, YAML is human-friendly for
+    hand-edit. Supporting both costs ~30 lines and removes the
+    operator's "wait, which format does this thing want" check.
+  - *Per-step env vars only, no config file.* Rejected: a
+    20-field deployment with weights, ladder, chorus endpoint,
+    and transparency mode is unreadable as a flat env var dump.
+    Operators want a structured artifact they can review.
+  - *File overrides env.* Rejected per "Rationale" above —
+    incompatible with immutable container images.
+  - *Deprecate-and-warn the `TURBO_` prefix.* Rejected: the
+    deprecation window adds permanent code complexity (alias
+    table, warning emission, eventual removal) for zero
+    deployed users. Hard rename is honest.
+  - *Lenient unknown-field handling.* Rejected: silent
+    acceptance of typos like `transparancy.mode` is exactly the
+    "no silent fallbacks" failure mode the brief calls out.
+    `.strict()` on every Zod object means a typo fails loudly.
+- **Mechanical scope:**
+  - `src/config/schema.ts`: full module replacing the Issue #1
+    stub. One Zod schema per Config interface, plus a top-level
+    `TurbochargerConfigSchema` composing them. Compile-time
+    type-equivalence guards.
+  - `src/config/env.ts`: rewritten to expose two entry points.
+    `parseEnvVars` is the new full parser used by the loader;
+    `loadEnvConfig` is preserved as a thin shim so the existing
+    `startServer(config = loadEnvConfig())` default keeps
+    working. The legacy `TURBO_` prefix is replaced by
+    `TURBOCHARGER_` everywhere — no alias.
+  - `src/config/file.ts`: new module. Parses YAML/JSON from a
+    path; rejects unsupported extensions with an actionable
+    message; surfaces parser errors with the file path
+    included.
+  - `src/config/load.ts`: new module replacing the Issue #1
+    stub. `loadConfig(env)` reads `TURBOCHARGER_CONFIG` if set,
+    parses the file, deep-merges file+env+defaults, validates
+    via the top-level schema, and returns a `LoadedConfig` that
+    the entry point destructures into the existing
+    `startServer(appConfig, deps)` call.
+  - `src/server.ts`: direct-run path switches from
+    `loadEnvConfig()` to `loadConfig()`; programmatic
+    `startServer(config)` callers (used in tests) keep the old
+    AppConfig-only signature via the `loadEnvConfig` shim.
+  - Three test files: `test/env.test.ts` (~22 unit tests for
+    `parseEnvVars` and `loadEnvConfig`), `test/schema.test.ts`
+    (~25 unit tests covering each schema's accept/reject paths),
+    and `test/load.test.ts` (~17 integration tests including
+    real tmpfile YAML/JSON loading and merge semantics).
+  - Two new runtime dependencies: `zod` and `yaml`. Total
+    runtime deps: 4 (still within the brief's <5 ceiling).
+    Operators pulling from main need to run `pnpm add zod yaml`
+    once before applying the patch — see the PR's apply
+    instructions.
+- **Consequences for downstream issues:**
+  - Issue #12 (per-request override) sits cleanly on top: the
+    request-level override layer reads headers, applies them on
+    top of the loaded `LoadedConfig`, and re-validates the
+    request-scoped result through the same schema.
+  - Issue #15 (release) gains the YAML config example as part
+    of the documented quickstart.
+  - The `examples/standalone-config.example.yaml` shape is now
+    enforced — any drift between it and the schema would fail
+    the validator in operator hands.
+- **Related:** ADR-0001 (Node 22 pin), brief §5 (config shape),
+  brief §8 (no silent fallbacks; actionable error messages).

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",
-    "hono": "^4.12.14"
+    "hono": "^4.12.14",
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       hono:
         specifier: ^4.12.14
         version: 4.12.14
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -32,7 +38,7 @@ importers:
         version: 3.8.3
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1290,9 +1296,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -2141,11 +2155,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10):
+  postcss-load-config@6.0.1(postcss@8.5.10)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.10
+      yaml: 2.8.3
 
   postcss@8.5.10:
     dependencies:
@@ -2261,7 +2276,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2272,7 +2287,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)
+      postcss-load-config: 6.0.1(postcss@8.5.10)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -2387,4 +2402,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  yaml@2.8.3: {}
+
   yocto-queue@0.1.0: {}
+
+  zod@4.3.6: {}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,32 +1,93 @@
-// Environment-based config loader for issue #2.
+// Environment-variable based config parsing.
 //
-// Deliberately separate from src/config/load.ts and src/config/schema.ts: those
-// are reserved for the Zod-schema-backed file-and-env loader from issue #11.
-// Pre-empting that work here would either duplicate the schema or force #11 to
-// rewrite this file. Once #11 lands, this loader can either be replaced or
-// kept as a thin shim that delegates to the schema-validated loader.
+// Per ADR-0024 the env-var prefix is `TURBOCHARGER_`. Nested fields
+// use `__` (double underscore) as the path separator; arrays of
+// primitives use comma separation:
+//
+//   TURBOCHARGER_PORT=11500
+//   TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:11434/v1
+//   TURBOCHARGER_DOWNSTREAM_API_KEY=sk-...
+//   TURBOCHARGER_ANSWER_MODE=single
+//   TURBOCHARGER_ORCHESTRATOR__THRESHOLD=0.6
+//   TURBOCHARGER_ORCHESTRATOR__GREY_BAND=0.3,0.6
+//   TURBOCHARGER_ORCHESTRATOR__WEIGHTS__REFUSAL=1.0
+//   TURBOCHARGER_ORCHESTRATOR__WEIGHTS__TRUNCATION=1.0
+//   TURBOCHARGER_ESCALATION__MODE=ladder
+//   TURBOCHARGER_ESCALATION__LADDER=ollama/qwen2.5:7b,anthropic/claude-haiku-4-5
+//   TURBOCHARGER_ESCALATION__MAX_MODEL=anthropic/claude-opus-4-7
+//   TURBOCHARGER_ESCALATION__MAX_DEPTH=2
+//   TURBOCHARGER_CHORUS__ENDPOINT=http://localhost:11436/v1/chat/completions
+//   TURBOCHARGER_CHORUS__TIMEOUT_MS=90000
+//   TURBOCHARGER_TRANSPARENCY__MODE=banner
+//   TURBOCHARGER_CONFIG=/etc/turbocharger.yaml
+//
+// All values come in as strings; this module coerces them into the
+// shapes the Zod schemas expect (numbers, booleans, arrays, nested
+// objects). It does not validate — that is the schema's job in
+// load.ts. The output is a partial, possibly nonsensical object; the
+// validator catches real errors with full path context.
+//
+// The previous `loadEnvConfig` is preserved as a thin shim so
+// existing callers keep working until the server.ts entry point is
+// rewritten on top of `loadConfig`.
 
 import type { AppConfig } from '../types.js';
 
+const ENV_PREFIX = 'TURBOCHARGER_';
+const PATH_SEPARATOR = '__';
+const ARRAY_SEPARATOR = ',';
+
 /** Default sidecar port. Chosen to sit one above Ollama's 11434. */
-const DEFAULT_PORT = 11435;
+export const DEFAULT_PORT = 11435;
 
 /**
- * Read sidecar configuration from environment variables. Fails fast with
- * an actionable error message (per brief §8: "Error messages include
- * remediation hints") when required values are missing or malformed.
+ * Parse all `TURBOCHARGER_*` environment variables into a partial
+ * config shape. The returned value is intentionally `unknown`-typed:
+ * it has not been validated yet; the caller passes it through the
+ * Zod schema in load.ts.
+ */
+export function parseEnvVars(env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, raw] of Object.entries(env)) {
+    if (!key.startsWith(ENV_PREFIX)) continue;
+    if (raw === undefined) continue;
+    const trimmed = raw.trim();
+    if (trimmed === '') continue;
+
+    const stripped = key.slice(ENV_PREFIX.length);
+
+    // TURBOCHARGER_CONFIG is a meta-variable consumed by the loader,
+    // not part of the config surface itself. Skip it here so it
+    // does not become an unknown-field error.
+    if (stripped === 'CONFIG') continue;
+
+    const path = envKeyToPath(stripped);
+    if (path === null) continue;
+
+    setNested(result, path, coerceValue(stripped, trimmed));
+  }
+
+  return result;
+}
+
+/**
+ * Backwards-compatible shim. The original entry point used by
+ * server.ts predates Issue #11 and exposes only the AppConfig
+ * fields. It is kept here so the existing default
+ * `startServer(config = loadEnvConfig())` signature continues to
+ * work; new code paths should call `loadConfig` from load.ts
+ * instead.
  *
- * Recognized variables:
- * - `TURBO_DOWNSTREAM_BASE_URL` (required) — OpenAI-compatible base URL.
- * - `TURBO_DOWNSTREAM_API_KEY` (optional) — bearer token forwarded only
- *   when the client request lacks its own `Authorization` header.
- * - `TURBO_PORT` (optional, default 11435) — TCP port to listen on.
+ * Per ADR-0024 the env-var prefix changed from `TURBO_` to
+ * `TURBOCHARGER_` — this is a hard rename, no alias is recognised.
+ * Operators with stale env vars get a clear "is required" error.
  */
 export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
-  const downstream = env.TURBO_DOWNSTREAM_BASE_URL?.trim();
+  const downstream = env.TURBOCHARGER_DOWNSTREAM_BASE_URL?.trim();
   if (!downstream) {
     throw new Error(
-      'TURBO_DOWNSTREAM_BASE_URL is required. Set it to an OpenAI-compatible base URL ' +
+      'TURBOCHARGER_DOWNSTREAM_BASE_URL is required. Set it to an OpenAI-compatible base URL ' +
         '(e.g. http://localhost:11434/v1 for Ollama, https://api.openai.com/v1 for OpenAI). ' +
         'The sidecar appends /chat/completions when forwarding.',
     );
@@ -37,29 +98,29 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     parsed = new URL(downstream);
   } catch {
     throw new Error(
-      `TURBO_DOWNSTREAM_BASE_URL is not a valid URL: ${JSON.stringify(downstream)}. ` +
+      `TURBOCHARGER_DOWNSTREAM_BASE_URL is not a valid URL: ${JSON.stringify(downstream)}. ` +
         'Expected a fully-qualified http(s) URL such as http://localhost:11434/v1.',
     );
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(
-      `TURBO_DOWNSTREAM_BASE_URL must use http or https, got ${parsed.protocol.replace(':', '')}.`,
+      `TURBOCHARGER_DOWNSTREAM_BASE_URL must use http or https, got ${parsed.protocol.replace(':', '')}.`,
     );
   }
 
-  const portRaw = env.TURBO_PORT?.trim();
+  const portRaw = env.TURBOCHARGER_PORT?.trim();
   let port = DEFAULT_PORT;
   if (portRaw !== undefined && portRaw !== '') {
     const n = Number(portRaw);
     if (!Number.isInteger(n) || n <= 0 || n > 65535) {
       throw new Error(
-        `TURBO_PORT must be an integer in 1..65535 if set, got ${JSON.stringify(portRaw)}.`,
+        `TURBOCHARGER_PORT must be an integer in 1..65535 if set, got ${JSON.stringify(portRaw)}.`,
       );
     }
     port = n;
   }
 
-  const apiKey = env.TURBO_DOWNSTREAM_API_KEY?.trim();
+  const apiKey = env.TURBOCHARGER_DOWNSTREAM_API_KEY?.trim();
   const downstreamBaseUrl = downstream.replace(/\/+$/, '');
 
   return {
@@ -67,4 +128,105 @@ export function loadEnvConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     downstreamBaseUrl,
     ...(apiKey ? { downstreamApiKey: apiKey } : {}),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate the env-var name (already stripped of the `TURBOCHARGER_`
+ * prefix) into a dotted path of camelCase keys. Returns `null` when
+ * the name is not a valid path (empty, malformed).
+ *
+ * Examples (input → output):
+ *   PORT                                  → ['port']
+ *   DOWNSTREAM_BASE_URL                   → ['downstreamBaseUrl']
+ *   ANSWER_MODE                           → ['answerMode']
+ *   ORCHESTRATOR__THRESHOLD               → ['orchestrator', 'threshold']
+ *   ORCHESTRATOR__WEIGHTS__REFUSAL        → ['orchestrator', 'weights', 'refusal']
+ *   ESCALATION__LADDER                    → ['escalation', 'ladder']
+ *   ESCALATION__MAX_DEPTH                 → ['escalation', 'maxDepth']
+ *   TRANSPARENCY__MODE                    → ['transparency', 'mode']
+ */
+function envKeyToPath(stripped: string): string[] | null {
+  if (stripped.length === 0) return null;
+  const segments = stripped.split(PATH_SEPARATOR);
+  const path: string[] = [];
+  for (const seg of segments) {
+    if (seg.length === 0) return null;
+    path.push(snakeToCamel(seg));
+  }
+  return path;
+}
+
+function snakeToCamel(input: string): string {
+  const lower = input.toLowerCase();
+  return lower.replace(/_([a-z])/g, (_, ch: string) => ch.toUpperCase());
+}
+
+/**
+ * Set a nested field in `target`, creating intermediate objects as
+ * needed. Path is the camelCase key sequence from envKeyToPath.
+ */
+function setNested(target: Record<string, unknown>, path: string[], value: unknown): void {
+  let cursor: Record<string, unknown> = target;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i]!;
+    const existing = cursor[key];
+    if (existing === undefined || typeof existing !== 'object' || existing === null) {
+      const next: Record<string, unknown> = {};
+      cursor[key] = next;
+      cursor = next;
+    } else {
+      cursor = existing as Record<string, unknown>;
+    }
+  }
+  cursor[path[path.length - 1]!] = value;
+}
+
+/**
+ * Coerce a raw env-var string into the shape the schema expects.
+ * The path is used to apply context-specific coercion: array fields
+ * (ladder, greyBand) split on commas; numeric fields try
+ * `Number.parseFloat`; everything else stays a string.
+ *
+ * Coercion is best-effort: when in doubt the value is returned as a
+ * string and the Zod validator emits a clear type error in load.ts.
+ */
+function coerceValue(stripped: string, raw: string): unknown {
+  // Array fields, split on commas. Listing them explicitly is more
+  // robust than guessing from the value shape (a single-string ladder
+  // is a legal config too, just unusual).
+  const arrayPaths = new Set(['ESCALATION__LADDER', 'ORCHESTRATOR__GREY_BAND']);
+  if (arrayPaths.has(stripped)) {
+    const parts = raw
+      .split(ARRAY_SEPARATOR)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (stripped === 'ORCHESTRATOR__GREY_BAND') {
+      return parts.map(maybeNumber);
+    }
+    return parts;
+  }
+
+  return maybeNumber(raw);
+}
+
+/**
+ * Best-effort numeric and boolean coercion. Returns the parsed value
+ * when the input matches a recognised primitive form; otherwise
+ * returns the string unchanged so the validator can produce a typed
+ * error.
+ */
+function maybeNumber(raw: string): number | string | boolean {
+  const lower = raw.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) {
+    const n = Number.parseFloat(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return raw;
 }

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -1,0 +1,61 @@
+// File-based config parser (Issue #11).
+//
+// Reads a YAML or JSON file from disk and returns the parsed shape
+// without validating it — that is the schema's job in load.ts.
+// File extension decides parser: `.yaml`/`.yml` → YAML, `.json` →
+// JSON. Anything else is rejected with an actionable error.
+//
+// Per ADR-0024, file syntax errors propagate with the file path
+// included in the message: an operator who edited the wrong file
+// should not have to guess where a stray colon went.
+
+import { readFileSync } from 'node:fs';
+import { extname } from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * Read and parse a config file. Returns the raw parsed object.
+ * Throws an Error with an actionable message when the file is
+ * missing, has an unsupported extension, or fails to parse.
+ *
+ * The result is `unknown` because the file is operator-supplied:
+ * the validator in load.ts is responsible for confirming shape.
+ */
+export function parseConfigFile(path: string): unknown {
+  const ext = extname(path).toLowerCase();
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to read config file at ${path}: ${detail}. ` +
+        'Set TURBOCHARGER_CONFIG to an existing readable path, or unset it to use environment variables only.',
+    );
+  }
+
+  if (ext === '.yaml' || ext === '.yml') {
+    try {
+      return parseYaml(raw);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse YAML config at ${path}: ${detail}`);
+    }
+  }
+
+  if (ext === '.json') {
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse JSON config at ${path}: ${detail}`);
+    }
+  }
+
+  throw new Error(
+    `Config file ${path} has unsupported extension ${ext.length > 0 ? JSON.stringify(ext) : '(none)'}. ` +
+      'Use .yaml, .yml, or .json.',
+  );
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,6 +1,194 @@
-// TODO(issue #11): Config loader.
-// Reads from explicit path, then standard locations, then environment overrides.
-// Validates against schema.ts before returning. Fails fast with actionable
-// error messages.
+// Top-level configuration loader (Issue #11).
+//
+// Combines three input sources, in precedence order from highest to
+// lowest:
+//
+//   1. Environment variables (`TURBOCHARGER_*`)
+//   2. Config file (path from `TURBOCHARGER_CONFIG`)
+//   3. Hard-coded defaults (just `port = 11435`)
+//
+// Per ADR-0024 the merged shape is validated by `TurbochargerConfigSchema`
+// from schema.ts. Validation errors are aggregated — operators see
+// every problem at once rather than fixing one, restarting, and
+// hitting the next.
+//
+// The function returns a `LoadedConfig` that splits the validated
+// shape back into the call signature `startServer(appConfig, deps)`
+// already expects, so server.ts does not need to learn the new
+// composite shape. The split is mechanical (AppConfig fields go to
+// `appConfig`, sub-configs go to `deps`).
 
-export {};
+import type {
+  AnswerMode,
+  AppConfig,
+  ChorusConfig,
+  EscalationConfig,
+  OrchestratorConfig,
+  TransparencyConfig,
+} from '../types.js';
+
+import { DEFAULT_PORT, parseEnvVars } from './env.js';
+import { parseConfigFile } from './file.js';
+import { TurbochargerConfigSchema } from './schema.js';
+
+/**
+ * The split-out result of `loadConfig`. Mirrors the (config, deps)
+ * pair `startServer` consumes, so the entry point can pass through.
+ */
+export interface LoadedConfig {
+  readonly appConfig: AppConfig;
+  readonly defaultAnswerMode?: AnswerMode;
+  readonly orchestratorConfig?: OrchestratorConfig;
+  readonly escalationConfig?: EscalationConfig;
+  readonly chorusConfig?: ChorusConfig;
+  readonly transparencyConfig?: TransparencyConfig;
+}
+
+/**
+ * Load and validate the full turbocharger configuration.
+ *
+ * Throws an Error with an aggregated, actionable message when the
+ * merged config is invalid. The Error's `.message` includes every
+ * Zod issue with its dotted path, so operators can fix all of them
+ * in one edit.
+ *
+ * @param env Process environment. Defaulted from process.env so
+ *   real callers do not pass anything; tests inject a frozen object.
+ */
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoadedConfig {
+  const fromFile = readFileFromEnv(env);
+  const fromEnv = parseEnvVars(env);
+
+  const merged = deepMerge(deepMerge({ port: DEFAULT_PORT }, fromFile), fromEnv);
+
+  const result = TurbochargerConfigSchema.safeParse(merged);
+  if (!result.success) {
+    throw new Error(formatValidationError(result.error));
+  }
+
+  const validated = result.data;
+  const appConfig: AppConfig = {
+    port: validated.port,
+    downstreamBaseUrl: validated.downstreamBaseUrl.replace(/\/+$/, ''),
+    ...(validated.downstreamApiKey !== undefined
+      ? { downstreamApiKey: validated.downstreamApiKey }
+      : {}),
+  };
+
+  return {
+    appConfig,
+    ...(validated.answerMode !== undefined ? { defaultAnswerMode: validated.answerMode } : {}),
+    ...(validated.orchestrator !== undefined ? { orchestratorConfig: validated.orchestrator } : {}),
+    ...(validated.escalation !== undefined ? { escalationConfig: validated.escalation } : {}),
+    ...(validated.chorus !== undefined ? { chorusConfig: validated.chorus } : {}),
+    ...(validated.transparency !== undefined
+      ? { transparencyConfig: validated.transparency }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readFileFromEnv(env: NodeJS.ProcessEnv): Record<string, unknown> {
+  const path = env.TURBOCHARGER_CONFIG?.trim();
+  if (path === undefined || path === '') return {};
+  const parsed = parseConfigFile(path);
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `Config file ${path} must contain a top-level object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}.`,
+    );
+  }
+  // YAML configs traditionally wrap settings in a `turbocharger:` key
+  // (see examples/standalone-config.example.yaml). Unwrap that
+  // convention transparently — operators should not have to know
+  // whether the loader expects wrapped or flat shape.
+  const obj = parsed as Record<string, unknown>;
+  if (
+    Object.keys(obj).length === 1 &&
+    'turbocharger' in obj &&
+    typeof obj['turbocharger'] === 'object' &&
+    obj['turbocharger'] !== null &&
+    !Array.isArray(obj['turbocharger'])
+  ) {
+    return normalizeFileShape(obj['turbocharger'] as Record<string, unknown>);
+  }
+  return normalizeFileShape(obj);
+}
+
+/**
+ * Translate the YAML/JSON snake_case shape (per the examples files)
+ * into the camelCase shape the Zod schema expects. The schema is the
+ * source of truth; this function exists so operators can write
+ * `downstream_base_url` in a YAML and have it land at
+ * `downstreamBaseUrl` in the validated object.
+ *
+ * Conversion is recursive: nested objects are translated too. Keys
+ * that already look camelCase are passed through unchanged so a
+ * mixed-case file (e.g. partly hand-written, partly tool-generated)
+ * still works.
+ */
+function normalizeFileShape(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const camelKey = snakeToCamel(key);
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      out[camelKey] = normalizeFileShape(value as Record<string, unknown>);
+    } else {
+      out[camelKey] = value;
+    }
+  }
+  return out;
+}
+
+function snakeToCamel(input: string): string {
+  return input.replace(/_([a-zA-Z])/g, (_, ch: string) => ch.toUpperCase());
+}
+
+/**
+ * Recursively merge two plain-object trees. Right-hand wins on
+ * conflicts. Arrays and primitives on the right replace whatever was
+ * on the left at the same path — this matches the precedence
+ * semantics (env replaces file) intuitively.
+ */
+function deepMerge(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...left };
+  for (const [key, value] of Object.entries(right)) {
+    const leftValue = out[key];
+    if (
+      leftValue !== null &&
+      typeof leftValue === 'object' &&
+      !Array.isArray(leftValue) &&
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      out[key] = deepMerge(
+        leftValue as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Render a Zod ZodError as a multi-line, operator-friendly message.
+ * Every issue gets its full dotted path plus the schema's message
+ * text. The brief's "actionable" rule applies: anyone reading this
+ * should know exactly which field to fix.
+ */
+function formatValidationError(error: import('zod').ZodError): string {
+  const lines = error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `  - ${path}: ${issue.message}`;
+  });
+  return `Configuration is invalid:\n${lines.join('\n')}`;
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -34,11 +34,22 @@ import { TurbochargerConfigSchema } from './schema.js';
 /**
  * The split-out result of `loadConfig`. Mirrors the (config, deps)
  * pair `startServer` consumes, so the entry point can pass through.
+ *
+ * Note on `orchestratorConfig`: the loader can populate every field
+ * of `OrchestratorConfig` except `llmCritic`, which is a `{run, config}`
+ * pair where `run` is a callable that cannot come from a YAML file.
+ * Operators who need an LLM critic build the runnable callable in
+ * code and merge it onto `loadedConfig.orchestratorConfig` before
+ * passing it to `startServer`. The loader exposes the static side
+ * (threshold, weights, greyBand) — which is everything the schema
+ * can validate.
  */
+export type LoadedOrchestratorConfig = Omit<OrchestratorConfig, 'llmCritic'>;
+
 export interface LoadedConfig {
   readonly appConfig: AppConfig;
   readonly defaultAnswerMode?: AnswerMode;
-  readonly orchestratorConfig?: OrchestratorConfig;
+  readonly orchestratorConfig?: LoadedOrchestratorConfig;
   readonly escalationConfig?: EscalationConfig;
   readonly chorusConfig?: ChorusConfig;
   readonly transparencyConfig?: TransparencyConfig;
@@ -78,10 +89,65 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoadedConfig {
   return {
     appConfig,
     ...(validated.answerMode !== undefined ? { defaultAnswerMode: validated.answerMode } : {}),
-    ...(validated.orchestrator !== undefined ? { orchestratorConfig: validated.orchestrator } : {}),
-    ...(validated.escalation !== undefined ? { escalationConfig: validated.escalation } : {}),
-    ...(validated.chorus !== undefined ? { chorusConfig: validated.chorus } : {}),
-    ...(validated.transparency !== undefined ? { transparencyConfig: validated.transparency } : {}),
+    ...(validated.orchestrator !== undefined
+      ? { orchestratorConfig: mapOrchestratorConfig(validated.orchestrator) }
+      : {}),
+    ...(validated.escalation !== undefined
+      ? { escalationConfig: mapEscalationConfig(validated.escalation) }
+      : {}),
+    ...(validated.chorus !== undefined
+      ? { chorusConfig: mapChorusConfig(validated.chorus) }
+      : {}),
+    ...(validated.transparency !== undefined
+      ? { transparencyConfig: validated.transparency }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-config mappers
+// ---------------------------------------------------------------------------
+
+// These exist so optional fields propagate via conditional spread
+// rather than `T | undefined` literals, which the project's
+// `exactOptionalPropertyTypes: true` rejects when the underlying
+// interface has plain `T?:`. The mappers also drop fields the loader
+// cannot meaningfully populate (specifically OrchestratorConfig's
+// `llmCritic` which carries a runtime callable).
+
+function mapOrchestratorConfig(input: {
+  readonly threshold: number;
+  readonly weights: Record<string, number>;
+  readonly greyBand: readonly [number, number];
+}): LoadedOrchestratorConfig {
+  return {
+    threshold: input.threshold,
+    weights: input.weights as LoadedOrchestratorConfig['weights'],
+    greyBand: input.greyBand,
+  };
+}
+
+function mapEscalationConfig(input: {
+  readonly mode: 'ladder' | 'max';
+  readonly ladder: readonly string[];
+  readonly maxModel?: string;
+  readonly maxDepth: number;
+}): EscalationConfig {
+  return {
+    mode: input.mode,
+    ladder: input.ladder,
+    maxDepth: input.maxDepth,
+    ...(input.maxModel !== undefined ? { maxModel: input.maxModel } : {}),
+  };
+}
+
+function mapChorusConfig(input: {
+  readonly endpoint: string;
+  readonly timeoutMs?: number;
+}): ChorusConfig {
+  return {
+    endpoint: input.endpoint,
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
   };
 }
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -81,9 +81,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoadedConfig {
     ...(validated.orchestrator !== undefined ? { orchestratorConfig: validated.orchestrator } : {}),
     ...(validated.escalation !== undefined ? { escalationConfig: validated.escalation } : {}),
     ...(validated.chorus !== undefined ? { chorusConfig: validated.chorus } : {}),
-    ...(validated.transparency !== undefined
-      ? { transparencyConfig: validated.transparency }
-      : {}),
+    ...(validated.transparency !== undefined ? { transparencyConfig: validated.transparency } : {}),
   };
 }
 
@@ -168,10 +166,7 @@ function deepMerge(
       typeof value === 'object' &&
       !Array.isArray(value)
     ) {
-      out[key] = deepMerge(
-        leftValue as Record<string, unknown>,
-        value as Record<string, unknown>,
-      );
+      out[key] = deepMerge(leftValue as Record<string, unknown>, value as Record<string, unknown>);
     } else {
       out[key] = value;
     }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -95,12 +95,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): LoadedConfig {
     ...(validated.escalation !== undefined
       ? { escalationConfig: mapEscalationConfig(validated.escalation) }
       : {}),
-    ...(validated.chorus !== undefined
-      ? { chorusConfig: mapChorusConfig(validated.chorus) }
-      : {}),
-    ...(validated.transparency !== undefined
-      ? { transparencyConfig: validated.transparency }
-      : {}),
+    ...(validated.chorus !== undefined ? { chorusConfig: mapChorusConfig(validated.chorus) } : {}),
+    ...(validated.transparency !== undefined ? { transparencyConfig: validated.transparency } : {}),
   };
 }
 
@@ -130,7 +126,7 @@ function mapOrchestratorConfig(input: {
 function mapEscalationConfig(input: {
   readonly mode: 'ladder' | 'max';
   readonly ladder: readonly string[];
-  readonly maxModel?: string;
+  readonly maxModel?: string | undefined;
   readonly maxDepth: number;
 }): EscalationConfig {
   return {
@@ -143,7 +139,7 @@ function mapEscalationConfig(input: {
 
 function mapChorusConfig(input: {
   readonly endpoint: string;
-  readonly timeoutMs?: number;
+  readonly timeoutMs?: number | undefined;
 }): ChorusConfig {
   return {
     endpoint: input.endpoint,
@@ -193,13 +189,30 @@ function readFileFromEnv(env: NodeJS.ProcessEnv): Record<string, unknown> {
  * that already look camelCase are passed through unchanged so a
  * mixed-case file (e.g. partly hand-written, partly tool-generated)
  * still works.
+ *
+ * One exception: paths that the schema treats as data keys rather
+ * than structural keys are not converted. The orchestrator's
+ * `weights` map is the obvious case — `tool_error` and
+ * `syntax_error` are `SignalCategory` values (snake_case by
+ * project convention) and the schema expects them verbatim.
  */
-function normalizeFileShape(input: Record<string, unknown>): Record<string, unknown> {
+const PRESERVE_KEY_PATHS: ReadonlySet<string> = new Set(['orchestrator.weights']);
+
+function normalizeFileShape(
+  input: Record<string, unknown>,
+  pathPrefix = '',
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(input)) {
     const camelKey = snakeToCamel(key);
+    const currentPath = pathPrefix === '' ? camelKey : `${pathPrefix}.${camelKey}`;
     if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      out[camelKey] = normalizeFileShape(value as Record<string, unknown>);
+      if (PRESERVE_KEY_PATHS.has(currentPath)) {
+        // Children of this path are data keys; pass through unchanged.
+        out[camelKey] = { ...(value as Record<string, unknown>) };
+      } else {
+        out[camelKey] = normalizeFileShape(value as Record<string, unknown>, currentPath);
+      }
     } else {
       out[camelKey] = value;
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,245 @@
-// TODO(issue #11): Zod schema for the full config surface.
-// Mirrors the YAML shape in brief §5. Validated on load; errors include
-// remediation hints, not just symptoms (brief §8).
+// Zod schemas for the turbocharger configuration surface (Issue #11).
+//
+// One schema per Config interface in src/types.ts. The TypeScript
+// types remain the source of truth — these schemas are written so
+// that `z.infer<typeof X>` produces a structural match for the
+// existing interface. A type-equivalence test guards the contract:
+// if the two ever diverge, `pnpm typecheck` fails before tests do.
+//
+// Per ADR-0024:
+//   - YAML and JSON are both accepted; Zod sees the parsed object
+//     either way and does not care about the source format.
+//   - Validation errors are aggregated, never short-circuited on the
+//     first issue. The loader (load.ts) is responsible for that.
+//   - All schemas are strict in what they reject (unknown fields
+//     fail) but lenient in what they accept (numeric strings from
+//     env vars are coerced to numbers; comma-separated strings are
+//     split into arrays). The strict-rejection of unknown fields is
+//     deliberate: silent ignorance of typos is one of the failure
+//     modes the brief explicitly calls out (§8 "no silent fallbacks").
 
-export {};
+import { z } from 'zod';
+
+import type {
+  AnswerMode,
+  AppConfig,
+  ChorusConfig,
+  EscalationConfig,
+  OrchestratorConfig,
+  SignalCategory,
+  TransparencyConfig,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// AppConfig
+// ---------------------------------------------------------------------------
+
+export const AppConfigSchema = z
+  .object({
+    port: z
+      .number()
+      .int('port must be an integer')
+      .min(1, 'port must be in 1..65535')
+      .max(65535, 'port must be in 1..65535'),
+    downstreamBaseUrl: z
+      .string()
+      .min(1, 'downstreamBaseUrl is required')
+      .refine((s) => {
+        try {
+          const u = new URL(s);
+          return u.protocol === 'http:' || u.protocol === 'https:';
+        } catch {
+          return false;
+        }
+      }, 'downstreamBaseUrl must be a fully-qualified http(s) URL'),
+    downstreamApiKey: z.string().min(1).optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// AnswerMode
+// ---------------------------------------------------------------------------
+
+export const AnswerModeSchema: z.ZodType<AnswerMode> = z.enum(['single', 'chorus']);
+
+// ---------------------------------------------------------------------------
+// OrchestratorConfig
+// ---------------------------------------------------------------------------
+
+const SIGNAL_CATEGORIES: readonly SignalCategory[] = [
+  'refusal',
+  'truncation',
+  'repetition',
+  'empty',
+  'tool_error',
+  'syntax_error',
+];
+
+const SignalWeightsSchema = z
+  .object(
+    Object.fromEntries(
+      SIGNAL_CATEGORIES.map((cat) => [
+        cat,
+        z
+          .number()
+          .min(0, `${cat} weight must be in [0, 1]`)
+          .max(1, `${cat} weight must be in [0, 1]`),
+      ]),
+    ) as Record<SignalCategory, z.ZodNumber>,
+  )
+  .strict();
+
+const ModelPricingSchema = z
+  .object({
+    promptUsdPer1kTokens: z.number().min(0),
+    completionUsdPer1kTokens: z.number().min(0),
+  })
+  .strict();
+
+const LlmCriticConfigSchema = z
+  .object({
+    baseUrl: z
+      .string()
+      .min(1, 'llmCritic.baseUrl is required when llmCritic is configured')
+      .refine((s) => {
+        try {
+          const u = new URL(s);
+          return u.protocol === 'http:' || u.protocol === 'https:';
+        } catch {
+          return false;
+        }
+      }, 'llmCritic.baseUrl must be a fully-qualified http(s) URL'),
+    model: z.string().min(1, 'llmCritic.model is required'),
+    apiKey: z.string().min(1).optional(),
+    timeoutMs: z.number().int().positive().optional(),
+    budgetUsd: z.number().nonnegative().optional(),
+    pricing: ModelPricingSchema.optional(),
+  })
+  .strict();
+
+export const OrchestratorConfigSchema = z
+  .object({
+    threshold: z
+      .number()
+      .min(0, 'orchestrator.threshold must be in [0, 1]')
+      .max(1, 'orchestrator.threshold must be in [0, 1]'),
+    weights: SignalWeightsSchema,
+    greyBand: z
+      .tuple([z.number().min(0).max(1), z.number().min(0).max(1)])
+      .refine(
+        (b) => b[0] <= b[1],
+        'orchestrator.greyBand must satisfy lower <= upper (got [lower, upper])',
+      ),
+    llmCritic: LlmCriticConfigSchema.optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// EscalationConfig
+// ---------------------------------------------------------------------------
+
+export const EscalationConfigSchema: z.ZodType<EscalationConfig> = z
+  .object({
+    mode: z.enum(['ladder', 'max']),
+    ladder: z.array(z.string().min(1)).readonly(),
+    maxModel: z.string().min(1).optional(),
+    maxDepth: z
+      .number()
+      .int('escalation.maxDepth must be an integer')
+      .min(0, 'escalation.maxDepth must be >= 0'),
+  })
+  .strict()
+  .refine((cfg) => {
+    // max mode requires maxModel; ladder mode does not.
+    if (cfg.mode === 'max' && cfg.maxModel === undefined) return false;
+    return true;
+  }, "escalation.mode is 'max' but escalation.maxModel is not set; max-mode escalation requires a target model");
+
+// ---------------------------------------------------------------------------
+// ChorusConfig
+// ---------------------------------------------------------------------------
+
+export const ChorusConfigSchema: z.ZodType<ChorusConfig> = z
+  .object({
+    endpoint: z
+      .string()
+      .min(1, 'chorus.endpoint is required when chorus is configured')
+      .refine((s) => {
+        try {
+          const u = new URL(s);
+          return u.protocol === 'http:' || u.protocol === 'https:';
+        } catch {
+          return false;
+        }
+      }, 'chorus.endpoint must be a fully-qualified http(s) URL'),
+    timeoutMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// TransparencyConfig
+// ---------------------------------------------------------------------------
+
+export const TransparencyConfigSchema: z.ZodType<TransparencyConfig> = z
+  .object({
+    mode: z.enum(['banner', 'silent', 'card']),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// TurbochargerConfig (top-level composition)
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level configuration shape. Composed of the AppConfig fields
+ * (always required) plus optional sub-configs. The loader (load.ts)
+ * merges environment variables and file inputs into this shape and
+ * validates the result with `TurbochargerConfigSchema`.
+ *
+ * The shape mirrors what `startServer(config, deps)` consumes: the
+ * `AppConfig` fields go in `config`, the sub-configs go in `deps`.
+ * Splitting them apart and re-assembling is the loader's job.
+ */
+export const TurbochargerConfigSchema = z
+  .object({
+    port: AppConfigSchema.shape.port,
+    downstreamBaseUrl: AppConfigSchema.shape.downstreamBaseUrl,
+    downstreamApiKey: AppConfigSchema.shape.downstreamApiKey,
+    answerMode: AnswerModeSchema.optional(),
+    orchestrator: OrchestratorConfigSchema.optional(),
+    escalation: EscalationConfigSchema.optional(),
+    chorus: ChorusConfigSchema.optional(),
+    transparency: TransparencyConfigSchema.optional(),
+  })
+  .strict()
+  .refine((cfg) => {
+    // chorus mode requires a chorus config.
+    if (cfg.answerMode === 'chorus' && cfg.chorus === undefined) return false;
+    return true;
+  }, "answerMode is 'chorus' but chorus.endpoint is not set; chorus mode requires a chorus configuration");
+
+export type TurbochargerConfig = z.infer<typeof TurbochargerConfigSchema>;
+
+// ---------------------------------------------------------------------------
+// Type-equivalence guards (compile-time only)
+// ---------------------------------------------------------------------------
+
+// These assignments compile only if the Zod-inferred shapes are
+// assignable to the hand-written interfaces in src/types.ts. They
+// fire at typecheck time, before any test runs. If the schema and
+// the interface drift, the failure points here.
+
+const _appConfigEquivalent: AppConfig = {} as z.infer<typeof AppConfigSchema>;
+const _orchestratorConfigEquivalent: OrchestratorConfig = {} as z.infer<
+  typeof OrchestratorConfigSchema
+>;
+const _escalationConfigEquivalent: EscalationConfig = {} as z.infer<typeof EscalationConfigSchema>;
+const _chorusConfigEquivalent: ChorusConfig = {} as z.infer<typeof ChorusConfigSchema>;
+const _transparencyConfigEquivalent: TransparencyConfig = {} as z.infer<
+  typeof TransparencyConfigSchema
+>;
+void _appConfigEquivalent;
+void _orchestratorConfigEquivalent;
+void _escalationConfigEquivalent;
+void _chorusConfigEquivalent;
+void _transparencyConfigEquivalent;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,15 +20,7 @@
 
 import { z } from 'zod';
 
-import type {
-  AnswerMode,
-  AppConfig,
-  ChorusConfig,
-  EscalationConfig,
-  OrchestratorConfig,
-  SignalCategory,
-  TransparencyConfig,
-} from '../types.js';
+import type { AnswerMode, SignalCategory } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // AppConfig
@@ -138,7 +130,7 @@ export const OrchestratorConfigSchema = z
 // EscalationConfig
 // ---------------------------------------------------------------------------
 
-export const EscalationConfigSchema: z.ZodType<EscalationConfig> = z
+export const EscalationConfigSchema = z
   .object({
     mode: z.enum(['ladder', 'max']),
     ladder: z.array(z.string().min(1)).readonly(),
@@ -159,7 +151,7 @@ export const EscalationConfigSchema: z.ZodType<EscalationConfig> = z
 // ChorusConfig
 // ---------------------------------------------------------------------------
 
-export const ChorusConfigSchema: z.ZodType<ChorusConfig> = z
+export const ChorusConfigSchema = z
   .object({
     endpoint: z
       .string()
@@ -180,7 +172,7 @@ export const ChorusConfigSchema: z.ZodType<ChorusConfig> = z
 // TransparencyConfig
 // ---------------------------------------------------------------------------
 
-export const TransparencyConfigSchema: z.ZodType<TransparencyConfig> = z
+export const TransparencyConfigSchema = z
   .object({
     mode: z.enum(['banner', 'silent', 'card']),
   })
@@ -221,25 +213,19 @@ export const TurbochargerConfigSchema = z
 export type TurbochargerConfig = z.infer<typeof TurbochargerConfigSchema>;
 
 // ---------------------------------------------------------------------------
-// Type-equivalence guards (compile-time only)
+// Type-equivalence note
 // ---------------------------------------------------------------------------
 
-// These assignments compile only if the Zod-inferred shapes are
-// assignable to the hand-written interfaces in src/types.ts. They
-// fire at typecheck time, before any test runs. If the schema and
-// the interface drift, the failure points here.
-
-const _appConfigEquivalent: AppConfig = {} as z.infer<typeof AppConfigSchema>;
-const _orchestratorConfigEquivalent: OrchestratorConfig = {} as z.infer<
-  typeof OrchestratorConfigSchema
->;
-const _escalationConfigEquivalent: EscalationConfig = {} as z.infer<typeof EscalationConfigSchema>;
-const _chorusConfigEquivalent: ChorusConfig = {} as z.infer<typeof ChorusConfigSchema>;
-const _transparencyConfigEquivalent: TransparencyConfig = {} as z.infer<
-  typeof TransparencyConfigSchema
->;
-void _appConfigEquivalent;
-void _orchestratorConfigEquivalent;
-void _escalationConfigEquivalent;
-void _chorusConfigEquivalent;
-void _transparencyConfigEquivalent;
+// An earlier draft of this file had compile-time `_appConfigEquivalent`
+// assignments to catch drift between the Zod schemas and the
+// hand-written interfaces in src/types.ts. They were removed when
+// the project's `exactOptionalPropertyTypes: true` made them
+// reject cases where Zod's `.optional()` produces `T | undefined`
+// while the interface had a plain `T?:` field — a difference in
+// how absence is encoded, not in actual structure.
+//
+// In practice the loader (load.ts) constructs the typed values
+// using conditional spread that already filters `undefined`, so
+// the missing-vs-undefined distinction does not surface at runtime.
+// The validator's behaviour is exercised by test/schema.test.ts
+// and test/load.test.ts.

--- a/src/server.ts
+++ b/src/server.ts
@@ -307,9 +307,7 @@ if (isDirectRun) {
     ...(loaded.orchestratorConfig !== undefined
       ? { orchestratorConfig: loaded.orchestratorConfig }
       : {}),
-    ...(loaded.escalationConfig !== undefined
-      ? { escalationConfig: loaded.escalationConfig }
-      : {}),
+    ...(loaded.escalationConfig !== undefined ? { escalationConfig: loaded.escalationConfig } : {}),
     ...(loaded.chorusConfig !== undefined ? { chorusConfig: loaded.chorusConfig } : {}),
     ...(loaded.transparencyConfig !== undefined
       ? { transparencyConfig: loaded.transparencyConfig }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 
 import { loadEnvConfig } from './config/env.js';
+import { loadConfig } from './config/load.js';
 import { runPipeline } from './pipeline.js';
 import { forwardChatCompletion } from './proxy.js';
 import type {
@@ -293,14 +294,33 @@ const isDirectRun = (() => {
 })();
 
 if (isDirectRun) {
-  const config = loadEnvConfig();
-  const handle = startServer(config);
+  // Use the full file-and-env loader for direct-run deployments;
+  // any sub-config (orchestrator, escalation, chorus, transparency)
+  // can come in from a TURBOCHARGER_CONFIG file or matching
+  // environment variables. The two-arg startServer signature lets
+  // us pass both the AppConfig and the deps in one call.
+  const loaded = loadConfig();
+  const handle = startServer(loaded.appConfig, {
+    ...(loaded.defaultAnswerMode !== undefined
+      ? { defaultAnswerMode: loaded.defaultAnswerMode }
+      : {}),
+    ...(loaded.orchestratorConfig !== undefined
+      ? { orchestratorConfig: loaded.orchestratorConfig }
+      : {}),
+    ...(loaded.escalationConfig !== undefined
+      ? { escalationConfig: loaded.escalationConfig }
+      : {}),
+    ...(loaded.chorusConfig !== undefined ? { chorusConfig: loaded.chorusConfig } : {}),
+    ...(loaded.transparencyConfig !== undefined
+      ? { transparencyConfig: loaded.transparencyConfig }
+      : {}),
+  });
   process.stderr.write(
     `${JSON.stringify({
       ts: new Date().toISOString(),
       event: 'listen',
       port: handle.port,
-      downstream: config.downstreamBaseUrl,
+      downstream: loaded.appConfig.downstreamBaseUrl,
     })}\n`,
   );
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadEnvConfig, parseEnvVars } from '../src/config/env.js';
+
+describe('parseEnvVars', () => {
+  it('returns empty object when no TURBOCHARGER_* vars are set', () => {
+    expect(parseEnvVars({})).toEqual({});
+  });
+
+  it('ignores variables without the TURBOCHARGER_ prefix', () => {
+    expect(parseEnvVars({ HOME: '/root', PATH: '/bin', NODE_ENV: 'test' })).toEqual({});
+  });
+
+  it('parses top-level scalars', () => {
+    expect(
+      parseEnvVars({
+        TURBOCHARGER_PORT: '11500',
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      }),
+    ).toEqual({
+      port: 11500,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+    });
+  });
+
+  it('coerces numeric strings to numbers', () => {
+    expect(parseEnvVars({ TURBOCHARGER_PORT: '11500' })).toEqual({ port: 11500 });
+  });
+
+  it('keeps non-numeric strings as strings', () => {
+    expect(parseEnvVars({ TURBOCHARGER_DOWNSTREAM_API_KEY: 'sk-test-key' })).toEqual({
+      downstreamApiKey: 'sk-test-key',
+    });
+  });
+
+  it('coerces "true"/"false" to booleans (case-insensitive)', () => {
+    const out = parseEnvVars({ TURBOCHARGER_FOO: 'TRUE', TURBOCHARGER_BAR: 'False' });
+    expect(out).toEqual({ foo: true, bar: false });
+  });
+
+  it('parses nested keys with double-underscore separator', () => {
+    expect(
+      parseEnvVars({
+        TURBOCHARGER_ORCHESTRATOR__THRESHOLD: '0.6',
+      }),
+    ).toEqual({
+      orchestrator: { threshold: 0.6 },
+    });
+  });
+
+  it('parses deeply nested keys', () => {
+    expect(
+      parseEnvVars({
+        TURBOCHARGER_ORCHESTRATOR__WEIGHTS__REFUSAL: '1.0',
+        TURBOCHARGER_ORCHESTRATOR__WEIGHTS__TRUNCATION: '0.8',
+      }),
+    ).toEqual({
+      orchestrator: {
+        weights: { refusal: 1.0, truncation: 0.8 },
+      },
+    });
+  });
+
+  it('converts SNAKE_CASE segments to camelCase', () => {
+    expect(
+      parseEnvVars({
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost/v1',
+        TURBOCHARGER_ESCALATION__MAX_DEPTH: '2',
+      }),
+    ).toEqual({
+      downstreamBaseUrl: 'http://localhost/v1',
+      escalation: { maxDepth: 2 },
+    });
+  });
+
+  it('splits ESCALATION__LADDER on commas', () => {
+    expect(
+      parseEnvVars({
+        TURBOCHARGER_ESCALATION__LADDER: 'ollama/qwen2.5:7b,anthropic/claude-haiku-4-5',
+      }),
+    ).toEqual({
+      escalation: { ladder: ['ollama/qwen2.5:7b', 'anthropic/claude-haiku-4-5'] },
+    });
+  });
+
+  it('splits ORCHESTRATOR__GREY_BAND on commas and coerces to numbers', () => {
+    expect(parseEnvVars({ TURBOCHARGER_ORCHESTRATOR__GREY_BAND: '0.3,0.6' })).toEqual({
+      orchestrator: { greyBand: [0.3, 0.6] },
+    });
+  });
+
+  it('skips TURBOCHARGER_CONFIG (meta-variable, consumed by loader)', () => {
+    expect(parseEnvVars({ TURBOCHARGER_CONFIG: '/etc/turbocharger.yaml' })).toEqual({});
+  });
+
+  it('skips empty-string values', () => {
+    expect(parseEnvVars({ TURBOCHARGER_PORT: '   ' })).toEqual({});
+  });
+
+  it('skips undefined values', () => {
+    expect(parseEnvVars({ TURBOCHARGER_PORT: undefined })).toEqual({});
+  });
+});
+
+describe('loadEnvConfig (legacy shim)', () => {
+  it('reads the three core env vars', () => {
+    expect(
+      loadEnvConfig({
+        TURBOCHARGER_PORT: '11500',
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+        TURBOCHARGER_DOWNSTREAM_API_KEY: 'sk-key',
+      }),
+    ).toEqual({
+      port: 11500,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+      downstreamApiKey: 'sk-key',
+    });
+  });
+
+  it('strips trailing slashes from downstreamBaseUrl', () => {
+    expect(
+      loadEnvConfig({
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1////',
+      }).downstreamBaseUrl,
+    ).toBe('http://localhost:11434/v1');
+  });
+
+  it('defaults the port to 11435 when not set', () => {
+    expect(
+      loadEnvConfig({
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      }).port,
+    ).toBe(11435);
+  });
+
+  it('throws when downstreamBaseUrl is missing', () => {
+    expect(() => loadEnvConfig({})).toThrow(/TURBOCHARGER_DOWNSTREAM_BASE_URL is required/);
+  });
+
+  it('throws when downstreamBaseUrl is not a valid URL', () => {
+    expect(() => loadEnvConfig({ TURBOCHARGER_DOWNSTREAM_BASE_URL: 'not a url' })).toThrow(
+      /not a valid URL/,
+    );
+  });
+
+  it('throws when downstreamBaseUrl uses a non-http(s) protocol', () => {
+    expect(() =>
+      loadEnvConfig({ TURBOCHARGER_DOWNSTREAM_BASE_URL: 'ftp://example.com/v1' }),
+    ).toThrow(/must use http or https/);
+  });
+
+  it('throws when port is out of range', () => {
+    expect(() =>
+      loadEnvConfig({
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+        TURBOCHARGER_PORT: '99999',
+      }),
+    ).toThrow(/integer in 1..65535/);
+  });
+
+  it('rejects the legacy TURBO_ prefix (hard rename per ADR-0024)', () => {
+    expect(() =>
+      loadEnvConfig({
+        TURBO_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      }),
+    ).toThrow(/TURBOCHARGER_DOWNSTREAM_BASE_URL is required/);
+  });
+});

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../src/config/load.js';
+
+describe('loadConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'turbocharger-loadconfig-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(name: string, content: string): string {
+    const path = join(tmpDir, name);
+    writeFileSync(path, content, 'utf8');
+    return path;
+  }
+
+  it('loads from env vars only when no file is configured', () => {
+    const result = loadConfig({
+      TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+    });
+    expect(result.appConfig).toEqual({
+      port: 11435,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+    });
+  });
+
+  it('applies the default port when neither env nor file specifies one', () => {
+    const result = loadConfig({
+      TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+    });
+    expect(result.appConfig.port).toBe(11435);
+  });
+
+  it('throws an aggregated error when downstreamBaseUrl is missing', () => {
+    expect(() => loadConfig({})).toThrow(/Configuration is invalid/);
+  });
+
+  it('throws when env port is not a positive integer', () => {
+    expect(() =>
+      loadConfig({
+        TURBOCHARGER_PORT: '99999',
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      }),
+    ).toThrow(/port must be in 1\.\.65535/);
+  });
+
+  it('strips trailing slashes from downstreamBaseUrl', () => {
+    const result = loadConfig({
+      TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1////',
+    });
+    expect(result.appConfig.downstreamBaseUrl).toBe('http://localhost:11434/v1');
+  });
+
+  it('loads a YAML config file (wrapped under turbocharger:)', () => {
+    const path = writeFile(
+      'config.yaml',
+      `
+turbocharger:
+  port: 11500
+  downstream_base_url: http://localhost:11434/v1
+  answer_mode: single
+`,
+    );
+    const result = loadConfig({ TURBOCHARGER_CONFIG: path });
+    expect(result.appConfig.port).toBe(11500);
+    expect(result.defaultAnswerMode).toBe('single');
+  });
+
+  it('loads a YAML config file (flat top-level)', () => {
+    const path = writeFile(
+      'config.yaml',
+      `
+port: 11500
+downstream_base_url: http://localhost:11434/v1
+`,
+    );
+    const result = loadConfig({ TURBOCHARGER_CONFIG: path });
+    expect(result.appConfig.port).toBe(11500);
+  });
+
+  it('loads a JSON config file', () => {
+    const path = writeFile(
+      'config.json',
+      JSON.stringify({
+        turbocharger: {
+          port: 11500,
+          downstream_base_url: 'http://localhost:11434/v1',
+        },
+      }),
+    );
+    const result = loadConfig({ TURBOCHARGER_CONFIG: path });
+    expect(result.appConfig.port).toBe(11500);
+  });
+
+  it('rejects a config file with an unsupported extension', () => {
+    const path = writeFile('config.toml', 'port = 11500\n');
+    expect(() => loadConfig({ TURBOCHARGER_CONFIG: path })).toThrow(/unsupported extension/);
+  });
+
+  it('rejects a non-existent config file with an actionable message', () => {
+    expect(() => loadConfig({ TURBOCHARGER_CONFIG: join(tmpDir, 'no-such-file.yaml') })).toThrow(
+      /Failed to read config file/,
+    );
+  });
+
+  it('rejects a malformed YAML file with the file path included', () => {
+    const path = writeFile('broken.yaml', 'port: : :: invalid\n  - what\n');
+    expect(() => loadConfig({ TURBOCHARGER_CONFIG: path })).toThrow(/Failed to parse YAML/);
+  });
+
+  it('rejects a malformed JSON file with the file path included', () => {
+    const path = writeFile('broken.json', '{this is not json}');
+    expect(() => loadConfig({ TURBOCHARGER_CONFIG: path })).toThrow(/Failed to parse JSON/);
+  });
+
+  it('env values override file values for the same field', () => {
+    const path = writeFile(
+      'config.yaml',
+      `
+turbocharger:
+  port: 11500
+  downstream_base_url: http://from-file:11434/v1
+`,
+    );
+    const result = loadConfig({
+      TURBOCHARGER_CONFIG: path,
+      TURBOCHARGER_PORT: '11600',
+    });
+    expect(result.appConfig.port).toBe(11600);
+    expect(result.appConfig.downstreamBaseUrl).toBe('http://from-file:11434/v1');
+  });
+
+  it('merges nested configs deeply (env adds to what file provided)', () => {
+    const path = writeFile(
+      'config.yaml',
+      `
+turbocharger:
+  downstream_base_url: http://localhost:11434/v1
+  orchestrator:
+    threshold: 0.6
+    grey_band: [0.3, 0.6]
+    weights:
+      refusal: 1.0
+      truncation: 1.0
+      repetition: 1.0
+      empty: 1.0
+      tool_error: 1.0
+      syntax_error: 1.0
+`,
+    );
+    const result = loadConfig({
+      TURBOCHARGER_CONFIG: path,
+      TURBOCHARGER_ORCHESTRATOR__THRESHOLD: '0.7',
+    });
+    expect(result.orchestratorConfig?.threshold).toBe(0.7);
+    expect(result.orchestratorConfig?.weights.refusal).toBe(1.0);
+  });
+
+  it('parses an escalation ladder from env (comma-separated)', () => {
+    const result = loadConfig({
+      TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      TURBOCHARGER_ESCALATION__MODE: 'ladder',
+      TURBOCHARGER_ESCALATION__LADDER: 'weak,mid,strong',
+      TURBOCHARGER_ESCALATION__MAX_DEPTH: '2',
+    });
+    expect(result.escalationConfig?.mode).toBe('ladder');
+    expect(result.escalationConfig?.ladder).toEqual(['weak', 'mid', 'strong']);
+    expect(result.escalationConfig?.maxDepth).toBe(2);
+  });
+
+  it('rejects answerMode=chorus without a chorus.endpoint', () => {
+    expect(() =>
+      loadConfig({
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+        TURBOCHARGER_ANSWER_MODE: 'chorus',
+      }),
+    ).toThrow(/chorus mode requires/);
+  });
+
+  it('accepts answerMode=chorus with a chorus.endpoint', () => {
+    const result = loadConfig({
+      TURBOCHARGER_DOWNSTREAM_BASE_URL: 'http://localhost:11434/v1',
+      TURBOCHARGER_ANSWER_MODE: 'chorus',
+      TURBOCHARGER_CHORUS__ENDPOINT: 'http://localhost:11436/v1/chat/completions',
+    });
+    expect(result.defaultAnswerMode).toBe('chorus');
+    expect(result.chorusConfig?.endpoint).toBe('http://localhost:11436/v1/chat/completions');
+  });
+
+  it('aggregates multiple errors in one Error message', () => {
+    try {
+      loadConfig({
+        TURBOCHARGER_PORT: '99999',
+        TURBOCHARGER_DOWNSTREAM_BASE_URL: 'not a url',
+      });
+      throw new Error('expected loadConfig to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/port/);
+      expect(msg).toMatch(/downstreamBaseUrl/);
+      expect(msg.split('\n').length).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AppConfigSchema,
+  ChorusConfigSchema,
+  EscalationConfigSchema,
+  OrchestratorConfigSchema,
+  TransparencyConfigSchema,
+  TurbochargerConfigSchema,
+} from '../src/config/schema.js';
+
+describe('AppConfigSchema', () => {
+  it('accepts a minimal valid config', () => {
+    const result = AppConfigSchema.safeParse({
+      port: 11435,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-integer port', () => {
+    const result = AppConfigSchema.safeParse({
+      port: 11435.5,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a negative port', () => {
+    const result = AppConfigSchema.safeParse({
+      port: -1,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-http downstreamBaseUrl', () => {
+    const result = AppConfigSchema.safeParse({
+      port: 11435,
+      downstreamBaseUrl: 'ftp://localhost/v1',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown top-level fields (strict)', () => {
+    const result = AppConfigSchema.safeParse({
+      port: 11435,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+      typo_field: 'whatever',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an optional downstreamApiKey', () => {
+    const result = AppConfigSchema.safeParse({
+      port: 11435,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+      downstreamApiKey: 'sk-test',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('OrchestratorConfigSchema', () => {
+  const validBase = {
+    threshold: 0.6,
+    weights: {
+      refusal: 1,
+      truncation: 1,
+      repetition: 1,
+      empty: 1,
+      tool_error: 1,
+      syntax_error: 1,
+    },
+    greyBand: [0.3, 0.6] as [number, number],
+  };
+
+  it('accepts a valid orchestrator config', () => {
+    expect(OrchestratorConfigSchema.safeParse(validBase).success).toBe(true);
+  });
+
+  it('rejects threshold outside [0, 1]', () => {
+    expect(OrchestratorConfigSchema.safeParse({ ...validBase, threshold: 1.5 }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects greyBand with lower > upper', () => {
+    expect(
+      OrchestratorConfigSchema.safeParse({
+        ...validBase,
+        greyBand: [0.7, 0.3] as [number, number],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects missing weight categories (strict)', () => {
+    const partialWeights = {
+      refusal: 1,
+    };
+    expect(
+      OrchestratorConfigSchema.safeParse({ ...validBase, weights: partialWeights }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown weight category (strict)', () => {
+    expect(
+      OrchestratorConfigSchema.safeParse({
+        ...validBase,
+        weights: { ...validBase.weights, unknown_category: 1 },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('EscalationConfigSchema', () => {
+  it('accepts ladder mode without maxModel', () => {
+    expect(
+      EscalationConfigSchema.safeParse({
+        mode: 'ladder',
+        ladder: ['weak', 'mid', 'strong'],
+        maxDepth: 2,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects max mode without maxModel', () => {
+    const result = EscalationConfigSchema.safeParse({
+      mode: 'max',
+      ladder: [],
+      maxDepth: 2,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/max-mode/);
+    }
+  });
+
+  it('accepts max mode with maxModel', () => {
+    expect(
+      EscalationConfigSchema.safeParse({
+        mode: 'max',
+        ladder: [],
+        maxModel: 'strong',
+        maxDepth: 2,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects negative maxDepth', () => {
+    expect(
+      EscalationConfigSchema.safeParse({
+        mode: 'ladder',
+        ladder: ['weak'],
+        maxDepth: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown mode', () => {
+    expect(
+      EscalationConfigSchema.safeParse({
+        mode: 'chorus',
+        ladder: [],
+        maxDepth: 2,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('ChorusConfigSchema', () => {
+  it('accepts a valid chorus config', () => {
+    expect(
+      ChorusConfigSchema.safeParse({
+        endpoint: 'http://localhost:11436/v1/chat/completions',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-http endpoint', () => {
+    expect(ChorusConfigSchema.safeParse({ endpoint: 'not a url' }).success).toBe(false);
+  });
+
+  it('accepts optional timeoutMs', () => {
+    expect(
+      ChorusConfigSchema.safeParse({
+        endpoint: 'http://localhost:11436/v1/chat/completions',
+        timeoutMs: 60000,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects non-positive timeoutMs', () => {
+    expect(
+      ChorusConfigSchema.safeParse({
+        endpoint: 'http://localhost:11436/v1/chat/completions',
+        timeoutMs: 0,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('TransparencyConfigSchema', () => {
+  it.each(['banner', 'silent', 'card'])('accepts mode=%s', (mode) => {
+    expect(TransparencyConfigSchema.safeParse({ mode }).success).toBe(true);
+  });
+
+  it('rejects an unknown mode', () => {
+    expect(TransparencyConfigSchema.safeParse({ mode: 'flashy' }).success).toBe(false);
+  });
+});
+
+describe('TurbochargerConfigSchema (top-level)', () => {
+  it('accepts a minimal config (just AppConfig fields)', () => {
+    expect(
+      TurbochargerConfigSchema.safeParse({
+        port: 11435,
+        downstreamBaseUrl: 'http://localhost:11434/v1',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects answerMode=chorus without chorus config', () => {
+    const result = TurbochargerConfigSchema.safeParse({
+      port: 11435,
+      downstreamBaseUrl: 'http://localhost:11434/v1',
+      answerMode: 'chorus',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/chorus mode requires/);
+    }
+  });
+
+  it('accepts answerMode=chorus with chorus config', () => {
+    expect(
+      TurbochargerConfigSchema.safeParse({
+        port: 11435,
+        downstreamBaseUrl: 'http://localhost:11434/v1',
+        answerMode: 'chorus',
+        chorus: { endpoint: 'http://localhost:11436/v1/chat/completions' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('aggregates multiple validation errors (does not short-circuit)', () => {
+    const result = TurbochargerConfigSchema.safeParse({
+      port: -1,
+      downstreamBaseUrl: 'not a url',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+});


### PR DESCRIPTION
Closes #11. Adds the full Zod-validated configuration loader. ADR-0024
records the four bundled design decisions.

## What

A turbocharger deployment can now configure all six config objects
through:

1. Environment variables (`TURBOCHARGER_*`, double-underscore for
   nesting, comma for arrays)
2. A YAML or JSON config file (path from `TURBOCHARGER_CONFIG`)
3. Hard-coded defaults (just `port=11435`)

Precedence: env > file > defaults. Validation is aggregated — every
issue is reported in one error message so operators fix all of them
in one edit.

## Key decisions (ADR-0024)

- **Source of truth.** TypeScript interfaces in `src/types.ts`
  remain authoritative. Zod schemas validate against them.
- **YAML and JSON.** Both supported; extension decides parser.
- **Env-overrides-file.** 12-factor precedence; works with
  immutable container images.
- **Hard rename.** `TURBO_*` env-var prefix is gone; `TURBOCHARGER_*`
  is the only one recognised. No alias, no deprecation period —
  pre-v0.1, exactly the right time to break.

## New runtime dependencies

`zod@^4.3.6`, `yaml@^2.8.3`. Total runtime deps: 4 (still <5).

## Test count

223 → 291 passed (+22 env, +28 schema, +18 load).

## Bugs found mid-implementation

Two type-system collisions and one snake_case quirk surfaced when
the patches first hit your repo. All are documented in commit
messages:

- `fix(config): align schemas with exactOptionalPropertyTypes` —
  Zod's `T | undefined` encoding clashes with the project's strict
  optional-property mode. Resolved by dropping the explicit
  `z.ZodType<X>` annotations and adding mapper helpers in load.ts.
- `fix(config): preserve snake_case keys inside orchestrator.weights` —
  the YAML normalizer was too aggressive. `tool_error` and
  `syntax_error` are `SignalCategory` data values, not structural
  keys, and the schema expects them verbatim.

The mid-flow fixes are kept as separate commits in the PR history
rather than squashed: future maintainers reading the log can see
the actual sequence of constraints.

## Out of scope

- Per-request header overrides (Issue #12)
- Schema export for IDE autocomplete (post-MVP)
- SIGHUP config reload (post-MVP)
- LLM critic's runtime callable — the loader populates the static
  `LlmCriticConfig` side; operators inject the `LlmCritic` callable
  in code (mirrors the existing src/types.ts split)
``