### PR TITLE
feat: per-request header overrides for AnswerMode and Transparency (Issue #12, ADR-0025)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1495,30 +1495,30 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     whole request. Logging the rejection on a header is
     cheaper for everyone.
 - **Alternatives considered:**
-  - *Three headers including `X-Turbocharger-Escalation-Mode`
-    (ladder|max).* Rejected for the MVP. The escalation
+  - _Three headers including `X-Turbocharger-Escalation-Mode`
+    (ladder|max)._ Rejected for the MVP. The escalation
     strategy is a deployment-wide cost-vs-quality tradeoff,
     not a per-request choice the client can sensibly make. If
     a future use case appears, the same tolerant-with-reject
     machinery accommodates it without redesign.
-  - *HTTP 400 on invalid value.* Rejected per "Rationale"
+  - _HTTP 400 on invalid value._ Rejected per "Rationale"
     above — the cost of refusing the request outweighs the
     benefit of a slightly louder failure signal.
-  - *Silent ignore of invalid values.* Rejected as a brief
+  - _Silent ignore of invalid values._ Rejected as a brief
     violation: silent fallbacks are exactly the failure mode
     §8 calls out.
-  - *JSON-structured `x-turbocharger-override-rejected`
-    header* (e.g. `[{"field":"transparency",…}]`). Rejected:
+  - _JSON-structured `x-turbocharger-override-rejected`
+    header_ (e.g. `[{"field":"transparency",…}]`). Rejected:
     response headers are line-oriented, JSON inside one header
     is awkward to read in `curl -v` and tools like nginx
     access logs typically truncate at commas anyway. The
     `field=value:reason` form parses with one `split(", ")`
     and one `split("=")`/`split(":")` pair per entry.
-  - *Allow override of `defaultAnswerMode` only when the
+  - _Allow override of `defaultAnswerMode` only when the
     overriding value matches what is configured (i.e. accept
     `single` if defaultAnswerMode is single; accept `chorus`
     only if a chorus is configured AND defaultAnswerMode is
-    chorus).* Rejected as too restrictive. The whole point of
+    chorus)._ Rejected as too restrictive. The whole point of
     a per-request override is that the request can pick an
     available mode the deployment supports but does not
     default to. The current rule is the right one: the

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1437,3 +1437,131 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
     the validator in operator hands.
 - **Related:** ADR-0001 (Node 22 pin), brief §5 (config shape),
   brief §8 (no silent fallbacks; actionable error messages).
+
+## ADR-0025: Per-request overrides via two headers, tolerant-with-reject
+
+- **Date:** 2026-04-30
+- **Status:** accepted, implements brief §5 ("Per-chat override")
+  and Issue #12.
+- **Decision:** Issue #12 wires per-request overrides on top of the
+  static configuration loaded by Issue #11. Four sub-decisions are
+  bundled because they describe one cohesive request-level layer:
+  1. **Two headers, not three.** `X-Turbocharger-Answer-Mode`
+     (`single`|`chorus`) and `X-Turbocharger-Transparency`
+     (`silent`|`banner`|`card`). Other configuration surfaces
+     (orchestrator weights, escalation ladder, chorus endpoint)
+     stay strictly server-side; per-request mutation of those
+     would let a misconfigured client cripple the deployment's
+     escalation behaviour or force-route to an attacker-controlled
+     chorus endpoint.
+  2. **Invalid values are rejected, not raised as 4xx.** When a
+     header carries an unrecognised value (typo, version skew),
+     the request continues with the configured defaults and the
+     response carries an `x-turbocharger-override-rejected`
+     header listing what was ignored. The header format is
+     `field=value:reason` entries comma-separated. This matches
+     the brief's "no silent fallbacks" rule (the rejection is
+     visible) without making the sidecar fragile to client typos.
+  3. **A `chorus` answer-mode override is rejected when no chorus
+     is configured.** Functionally the same path as an invalid
+     value, but with the dedicated `chorus-config-missing`
+     reason so monitoring tools can distinguish "client typo"
+     from "deployment lacks chorus support". The request
+     continues in single mode.
+  4. **Tracking.** `DecisionLogEntry` gains three optional
+     fields: `answer_mode_override`, `transparency_mode_override`,
+     and `override_rejected`. Response headers
+     `x-turbocharger-answer-mode` and (when relevant) the
+     transparency-emitted markers reflect the effective mode,
+     not the default. An operator looking at logs or response
+     headers can always tell which mode actually ran and why.
+- **Rationale:** The four sub-decisions all flow from one core
+  question: should per-request overrides be powerful or
+  defensive. Powerful overrides (every config field, opaque JSON
+  blob, no validation) hand the request author too much rope
+  for a sidecar that sits between an LLM client and an LLM
+  provider. Defensive overrides (two well-known fields, strict
+  enum validation, transparent rejection) cover the named use
+  cases in the brief — per-chat answer mode, per-request
+  visibility level — without expanding the attack surface.
+  Tolerant-with-reject specifically beats hard 4xx because:
+  - A client setting a transparency value the server does not
+    know about is more likely to be running a stale build than
+    sending hostile traffic. The "right" failure mode is to
+    proceed with defaults, not to refuse the underlying chat
+    completion.
+  - Returning 4xx loses the chat completion entirely, which
+    the request author cannot recover from without redoing the
+    whole request. Logging the rejection on a header is
+    cheaper for everyone.
+- **Alternatives considered:**
+  - *Three headers including `X-Turbocharger-Escalation-Mode`
+    (ladder|max).* Rejected for the MVP. The escalation
+    strategy is a deployment-wide cost-vs-quality tradeoff,
+    not a per-request choice the client can sensibly make. If
+    a future use case appears, the same tolerant-with-reject
+    machinery accommodates it without redesign.
+  - *HTTP 400 on invalid value.* Rejected per "Rationale"
+    above — the cost of refusing the request outweighs the
+    benefit of a slightly louder failure signal.
+  - *Silent ignore of invalid values.* Rejected as a brief
+    violation: silent fallbacks are exactly the failure mode
+    §8 calls out.
+  - *JSON-structured `x-turbocharger-override-rejected`
+    header* (e.g. `[{"field":"transparency",…}]`). Rejected:
+    response headers are line-oriented, JSON inside one header
+    is awkward to read in `curl -v` and tools like nginx
+    access logs typically truncate at commas anyway. The
+    `field=value:reason` form parses with one `split(", ")`
+    and one `split("=")`/`split(":")` pair per entry.
+  - *Allow override of `defaultAnswerMode` only when the
+    overriding value matches what is configured (i.e. accept
+    `single` if defaultAnswerMode is single; accept `chorus`
+    only if a chorus is configured AND defaultAnswerMode is
+    chorus).* Rejected as too restrictive. The whole point of
+    a per-request override is that the request can pick an
+    available mode the deployment supports but does not
+    default to. The current rule is the right one: the
+    override is rejected only when the requested mode is
+    structurally impossible (chorus without a chorus
+    endpoint), not when it merely differs from the default.
+- **Mechanical scope:**
+  - `src/config/overrides.ts`: new module. Exports
+    `parseRequestOverrides(headers, chorusConfig)` and
+    `formatRejectedHeader(rejected)`. Parsing is
+    case-insensitive on header values, trims whitespace, and
+    silently ignores empty-after-trim values (more likely a
+    client bug than a deliberate signal).
+  - `src/server.ts`: invokes the parser at the start of the
+    `POST /v1/chat/completions` handler, derives
+    `effectiveAnswerMode` and `effectiveTransparencyConfig`,
+    forwards them to `runPipeline`, and sets the
+    `x-turbocharger-override-rejected` response header when
+    relevant. `DecisionLogEntry` gains the three new fields.
+  - `test/overrides.test.ts`: ~12 unit tests covering each
+    valid value, each rejection path, case-insensitivity,
+    whitespace handling, the empty-string edge case, and the
+    rejected-header formatter.
+  - `test/pipeline-overrides.test.ts`: ~6 integration tests
+    that drive the full sidecar with `fetch`: transparency
+    override changes the visible output, silent override
+    suppresses a banner default, chorus override without
+    chorus config produces the right rejection header,
+    invalid header values continue the request with the
+    rejection visible, no-override requests are unchanged,
+    combined overrides work.
+- **Consequences for downstream issues:**
+  - Issue #15 (release): the README should mention the two
+    headers under "Configuration" so the v0.1 surface is
+    documented. CONFIGURATION.md should grow a "per-request
+    overrides" section.
+  - The `x-turbocharger-answer-mode` response header now
+    reflects the **effective** mode, not the configured
+    default. Anyone consuming that header in dashboards or
+    logs sees the truth of what ran, not the configured
+    intention.
+- **Related:** ADR-0021 (chorus is an AnswerMode, not an
+  escalation strategy), ADR-0022 (banner opt-in / silent
+  default), ADR-0023 (card structure), ADR-0024 (the static
+  configuration surface this layer sits on top of), brief
+  §5 ("Per-chat override"), brief §8 ("no silent fallbacks").

--- a/src/config/overrides.ts
+++ b/src/config/overrides.ts
@@ -1,0 +1,127 @@
+// Per-request header overrides (Issue #12).
+//
+// Two headers are recognised, both case-insensitive (HTTP-spec):
+//
+//   X-Turbocharger-Answer-Mode: single | chorus
+//   X-Turbocharger-Transparency: silent | banner | card
+//
+// Per ADR-0025 the design is tolerant-with-reject: invalid header
+// values do not fail the request. Instead they are listed in a
+// response-side `x-turbocharger-override-rejected` header so the
+// client sees what was ignored. The request continues with the
+// configured defaults, never silently. This matches the brief's
+// "no silent fallbacks" rule while keeping the sidecar resilient
+// against client typos and version skew.
+//
+// A chorus-mode override against a deployment without a chorus
+// configuration is a special case of the same pattern: the override
+// is rejected (chorus needs an endpoint, no endpoint configured),
+// the request continues in single mode.
+
+import type { AnswerMode, ChorusConfig, TransparencyConfig } from '../types.js';
+
+const HEADER_ANSWER_MODE = 'x-turbocharger-answer-mode';
+const HEADER_TRANSPARENCY = 'x-turbocharger-transparency';
+
+/**
+ * Reasons an override was rejected. Exposed so server.ts can emit
+ * them on the `x-turbocharger-override-rejected` response header
+ * and on the structured log line.
+ */
+export interface OverrideReject {
+  readonly field: 'answer-mode' | 'transparency';
+  readonly value: string;
+  readonly reason: 'invalid-value' | 'chorus-config-missing';
+}
+
+export interface RequestOverrides {
+  readonly answerMode?: AnswerMode;
+  readonly transparencyMode?: TransparencyConfig['mode'];
+  readonly rejected: readonly OverrideReject[];
+}
+
+/**
+ * Parse request headers into a `RequestOverrides`. The `chorusConfig`
+ * argument is consulted only to validate a chorus-mode override:
+ * when the request asks for chorus mode but no chorus endpoint is
+ * configured, the override is rejected.
+ *
+ * The function never throws. Anything that cannot be parsed becomes
+ * a {@link OverrideReject} entry; the caller decides what to do
+ * with the list (typically: emit them as a response header so the
+ * client knows, then proceed with defaults).
+ */
+export function parseRequestOverrides(
+  headers: Headers,
+  chorusConfig: ChorusConfig | undefined,
+): RequestOverrides {
+  const rejected: OverrideReject[] = [];
+  let answerMode: AnswerMode | undefined;
+  let transparencyMode: TransparencyConfig['mode'] | undefined;
+
+  const rawAnswer = headers.get(HEADER_ANSWER_MODE);
+  if (rawAnswer !== null) {
+    const trimmed = rawAnswer.trim().toLowerCase();
+    if (trimmed === 'single') {
+      answerMode = 'single';
+    } else if (trimmed === 'chorus') {
+      if (chorusConfig === undefined) {
+        rejected.push({
+          field: 'answer-mode',
+          value: trimmed,
+          reason: 'chorus-config-missing',
+        });
+      } else {
+        answerMode = 'chorus';
+      }
+    } else if (trimmed.length > 0) {
+      rejected.push({
+        field: 'answer-mode',
+        value: trimmed,
+        reason: 'invalid-value',
+      });
+    }
+    // empty string after trim: silently ignore — header was set but
+    // empty, which is more likely a client bug than a deliberate
+    // value to validate against.
+  }
+
+  const rawTransparency = headers.get(HEADER_TRANSPARENCY);
+  if (rawTransparency !== null) {
+    const trimmed = rawTransparency.trim().toLowerCase();
+    if (trimmed === 'silent' || trimmed === 'banner' || trimmed === 'card') {
+      transparencyMode = trimmed;
+    } else if (trimmed.length > 0) {
+      rejected.push({
+        field: 'transparency',
+        value: trimmed,
+        reason: 'invalid-value',
+      });
+    }
+  }
+
+  return {
+    ...(answerMode !== undefined ? { answerMode } : {}),
+    ...(transparencyMode !== undefined ? { transparencyMode } : {}),
+    rejected,
+  };
+}
+
+/**
+ * Render the rejection list as the value for the
+ * `x-turbocharger-override-rejected` response header. Returns
+ * `null` when there is nothing to emit so the caller can skip
+ * setting the header entirely.
+ *
+ * Format: comma-separated `field=value:reason` entries. Example:
+ *
+ *   x-turbocharger-override-rejected: answer-mode=dance:invalid-value, transparency=flashy:invalid-value
+ *
+ * The value-after-colon disambiguates the two rejection reasons
+ * (invalid-value vs chorus-config-missing) so monitoring tools can
+ * tell why each entry was dropped without parsing the value text.
+ */
+export function formatRejectedHeader(rejected: readonly OverrideReject[]): string | null {
+  if (rejected.length === 0) return null;
+  return rejected.map((r) => `${r.field}=${r.value}:${r.reason}`).join(', ');
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -253,9 +253,7 @@ export function createApp(deps: AppDeps): Hono {
         status,
         latency_ms: Date.now() - start,
         ...(answerMode !== undefined ? { answer_mode: answerMode } : {}),
-        ...(answerModeOverride !== undefined
-          ? { answer_mode_override: answerModeOverride }
-          : {}),
+        ...(answerModeOverride !== undefined ? { answer_mode_override: answerModeOverride } : {}),
         ...(decisionKind !== undefined ? { decision: decisionKind } : {}),
         ...(decisionReason !== undefined ? { decision_reason: decisionReason } : {}),
         ...(escalationDepth !== undefined ? { escalation_depth: escalationDepth } : {}),
@@ -271,9 +269,7 @@ export function createApp(deps: AppDeps): Hono {
           : {}),
         ...(overrides.rejected.length > 0
           ? {
-              override_rejected: overrides.rejected.map(
-                (r) => `${r.field}=${r.value}:${r.reason}`,
-              ),
+              override_rejected: overrides.rejected.map((r) => `${r.field}=${r.value}:${r.reason}`),
             }
           : {}),
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { Hono } from 'hono';
 
 import { loadEnvConfig } from './config/env.js';
 import { loadConfig } from './config/load.js';
+import { formatRejectedHeader, parseRequestOverrides } from './config/overrides.js';
 import { runPipeline } from './pipeline.js';
 import { forwardChatCompletion } from './proxy.js';
 import type {
@@ -89,6 +90,7 @@ export interface AppDeps {
  */
 export interface DecisionLogEntry extends RequestLogEntry {
   readonly answer_mode?: AnswerMode;
+  readonly answer_mode_override?: AnswerMode;
   readonly decision?: OrchestratorDecision['kind'];
   readonly decision_reason?: string;
   readonly escalation_depth?: number;
@@ -97,6 +99,8 @@ export interface DecisionLogEntry extends RequestLogEntry {
   readonly chorus_outcome?: ChorusTrace['outcome'];
   readonly chorus_detail?: string;
   readonly transparency_mode?: TransparencyConfig['mode'];
+  readonly transparency_mode_override?: TransparencyConfig['mode'];
+  readonly override_rejected?: readonly string[];
 }
 
 const defaultLogger: RequestLogger = (entry) => {
@@ -136,6 +140,8 @@ export function createApp(deps: AppDeps): Hono {
     const start = Date.now();
     let status = 0;
     let answerMode: AnswerMode | undefined;
+    let answerModeOverride: AnswerMode | undefined;
+    let transparencyModeOverride: TransparencyConfig['mode'] | undefined;
     let decisionKind: OrchestratorDecision['kind'] | undefined;
     let decisionReason: string | undefined;
     let escalationDepth: number | undefined;
@@ -144,8 +150,25 @@ export function createApp(deps: AppDeps): Hono {
     let chorusOutcome: ChorusTrace['outcome'] | undefined;
     let chorusDetail: string | undefined;
 
+    // Parse per-request overrides (Issue #12). Invalid values do not
+    // fail the request; they are listed in `rejected` and surface on
+    // the response header so clients can detect what was ignored.
+    const overrides = parseRequestOverrides(c.req.raw.headers, deps.chorusConfig);
+    const effectiveAnswerMode: AnswerMode = overrides.answerMode ?? defaultAnswerMode;
+    const effectiveTransparencyConfig: TransparencyConfig | undefined =
+      overrides.transparencyMode !== undefined
+        ? { mode: overrides.transparencyMode }
+        : deps.transparencyConfig;
+    if (overrides.answerMode !== undefined) {
+      answerModeOverride = overrides.answerMode;
+    }
+    if (overrides.transparencyMode !== undefined) {
+      transparencyModeOverride = overrides.transparencyMode;
+    }
+    const rejectedHeaderValue = formatRejectedHeader(overrides.rejected);
+
     try {
-      if (defaultAnswerMode === 'chorus') {
+      if (effectiveAnswerMode === 'chorus') {
         // Chorus mode: orchestratorConfig is not required; pipeline
         // dispatches directly to the chorus endpoint.
         answerMode = 'chorus';
@@ -164,6 +187,9 @@ export function createApp(deps: AppDeps): Hono {
             chorusDetail = result.trace.detail;
           }
         }
+        if (rejectedHeaderValue !== null) {
+          result.response.headers.set('x-turbocharger-override-rejected', rejectedHeaderValue);
+        }
         return result.response;
       }
 
@@ -178,8 +204,8 @@ export function createApp(deps: AppDeps): Hono {
           ...(deps.escalationConfig !== undefined
             ? { escalationConfig: deps.escalationConfig }
             : {}),
-          ...(deps.transparencyConfig !== undefined
-            ? { transparencyConfig: deps.transparencyConfig }
+          ...(effectiveTransparencyConfig !== undefined
+            ? { transparencyConfig: effectiveTransparencyConfig }
             : {}),
         });
         status = result.response.status;
@@ -194,12 +220,18 @@ export function createApp(deps: AppDeps): Hono {
             escalationPath = result.trace.path;
           }
         }
+        if (rejectedHeaderValue !== null) {
+          result.response.headers.set('x-turbocharger-override-rejected', rejectedHeaderValue);
+        }
         return result.response;
       }
 
       // No orchestrator, pass-through proxy (issue #2).
       const downstream = await forwardChatCompletion(c.req.raw, deps.proxyTarget);
       status = downstream.status;
+      if (rejectedHeaderValue !== null) {
+        downstream.headers.set('x-turbocharger-override-rejected', rejectedHeaderValue);
+      }
       return downstream;
     } catch (err) {
       status = 502;
@@ -221,6 +253,9 @@ export function createApp(deps: AppDeps): Hono {
         status,
         latency_ms: Date.now() - start,
         ...(answerMode !== undefined ? { answer_mode: answerMode } : {}),
+        ...(answerModeOverride !== undefined
+          ? { answer_mode_override: answerModeOverride }
+          : {}),
         ...(decisionKind !== undefined ? { decision: decisionKind } : {}),
         ...(decisionReason !== undefined ? { decision_reason: decisionReason } : {}),
         ...(escalationDepth !== undefined ? { escalation_depth: escalationDepth } : {}),
@@ -228,8 +263,18 @@ export function createApp(deps: AppDeps): Hono {
         ...(escalationPath !== undefined ? { escalation_path: escalationPath } : {}),
         ...(chorusOutcome !== undefined ? { chorus_outcome: chorusOutcome } : {}),
         ...(chorusDetail !== undefined ? { chorus_detail: chorusDetail } : {}),
-        ...(deps.transparencyConfig !== undefined
-          ? { transparency_mode: deps.transparencyConfig.mode }
+        ...(effectiveTransparencyConfig !== undefined
+          ? { transparency_mode: effectiveTransparencyConfig.mode }
+          : {}),
+        ...(transparencyModeOverride !== undefined
+          ? { transparency_mode_override: transparencyModeOverride }
+          : {}),
+        ...(overrides.rejected.length > 0
+          ? {
+              override_rejected: overrides.rejected.map(
+                (r) => `${r.field}=${r.value}:${r.reason}`,
+              ),
+            }
           : {}),
       };
       log(entry);

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  formatRejectedHeader,
-  parseRequestOverrides,
-} from '../src/config/overrides.js';
+import { formatRejectedHeader, parseRequestOverrides } from '../src/config/overrides.js';
 import type { ChorusConfig } from '../src/types.js';
 
 const chorusConfigured: ChorusConfig = {
@@ -126,9 +123,7 @@ describe('formatRejectedHeader', () => {
 
   it('renders one rejection as field=value:reason', () => {
     expect(
-      formatRejectedHeader([
-        { field: 'answer-mode', value: 'dance', reason: 'invalid-value' },
-      ]),
+      formatRejectedHeader([{ field: 'answer-mode', value: 'dance', reason: 'invalid-value' }]),
     ).toBe('answer-mode=dance:invalid-value');
   });
 

--- a/test/overrides.test.ts
+++ b/test/overrides.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatRejectedHeader,
+  parseRequestOverrides,
+} from '../src/config/overrides.js';
+import type { ChorusConfig } from '../src/types.js';
+
+const chorusConfigured: ChorusConfig = {
+  endpoint: 'http://localhost:11436/v1/chat/completions',
+};
+
+describe('parseRequestOverrides', () => {
+  it('returns no overrides and empty rejected list when no headers are set', () => {
+    const result = parseRequestOverrides(new Headers(), chorusConfigured);
+    expect(result.answerMode).toBeUndefined();
+    expect(result.transparencyMode).toBeUndefined();
+    expect(result.rejected).toEqual([]);
+  });
+
+  it('parses X-Turbocharger-Answer-Mode: single', () => {
+    const headers = new Headers({ 'x-turbocharger-answer-mode': 'single' });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBe('single');
+    expect(result.rejected).toEqual([]);
+  });
+
+  it('parses X-Turbocharger-Answer-Mode: chorus when chorus is configured', () => {
+    const headers = new Headers({ 'x-turbocharger-answer-mode': 'chorus' });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBe('chorus');
+    expect(result.rejected).toEqual([]);
+  });
+
+  it('rejects chorus override when chorus is not configured', () => {
+    const headers = new Headers({ 'x-turbocharger-answer-mode': 'chorus' });
+    const result = parseRequestOverrides(headers, undefined);
+    expect(result.answerMode).toBeUndefined();
+    expect(result.rejected).toEqual([
+      { field: 'answer-mode', value: 'chorus', reason: 'chorus-config-missing' },
+    ]);
+  });
+
+  it('rejects an unrecognised answer-mode value', () => {
+    const headers = new Headers({ 'x-turbocharger-answer-mode': 'dance' });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBeUndefined();
+    expect(result.rejected).toEqual([
+      { field: 'answer-mode', value: 'dance', reason: 'invalid-value' },
+    ]);
+  });
+
+  it.each(['silent', 'banner', 'card'] as const)(
+    'parses X-Turbocharger-Transparency: %s',
+    (mode) => {
+      const headers = new Headers({ 'x-turbocharger-transparency': mode });
+      const result = parseRequestOverrides(headers, chorusConfigured);
+      expect(result.transparencyMode).toBe(mode);
+      expect(result.rejected).toEqual([]);
+    },
+  );
+
+  it('rejects an unrecognised transparency value', () => {
+    const headers = new Headers({ 'x-turbocharger-transparency': 'flashy' });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.transparencyMode).toBeUndefined();
+    expect(result.rejected).toEqual([
+      { field: 'transparency', value: 'flashy', reason: 'invalid-value' },
+    ]);
+  });
+
+  it('parses both headers together', () => {
+    const headers = new Headers({
+      'x-turbocharger-answer-mode': 'single',
+      'x-turbocharger-transparency': 'card',
+    });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBe('single');
+    expect(result.transparencyMode).toBe('card');
+    expect(result.rejected).toEqual([]);
+  });
+
+  it('aggregates multiple rejections into one list', () => {
+    const headers = new Headers({
+      'x-turbocharger-answer-mode': 'dance',
+      'x-turbocharger-transparency': 'flashy',
+    });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBeUndefined();
+    expect(result.transparencyMode).toBeUndefined();
+    expect(result.rejected).toHaveLength(2);
+  });
+
+  it('treats header values case-insensitively', () => {
+    const headers = new Headers({
+      'x-turbocharger-answer-mode': 'CHORUS',
+      'x-turbocharger-transparency': 'Banner',
+    });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBe('chorus');
+    expect(result.transparencyMode).toBe('banner');
+  });
+
+  it('trims whitespace around header values', () => {
+    const headers = new Headers({ 'x-turbocharger-answer-mode': '  single  ' });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBe('single');
+  });
+
+  it('silently ignores empty-string header values (likely client bug)', () => {
+    const headers = new Headers({
+      'x-turbocharger-answer-mode': '   ',
+      'x-turbocharger-transparency': '',
+    });
+    const result = parseRequestOverrides(headers, chorusConfigured);
+    expect(result.answerMode).toBeUndefined();
+    expect(result.transparencyMode).toBeUndefined();
+    expect(result.rejected).toEqual([]);
+  });
+});
+
+describe('formatRejectedHeader', () => {
+  it('returns null when nothing was rejected', () => {
+    expect(formatRejectedHeader([])).toBeNull();
+  });
+
+  it('renders one rejection as field=value:reason', () => {
+    expect(
+      formatRejectedHeader([
+        { field: 'answer-mode', value: 'dance', reason: 'invalid-value' },
+      ]),
+    ).toBe('answer-mode=dance:invalid-value');
+  });
+
+  it('joins multiple rejections with comma-space', () => {
+    expect(
+      formatRejectedHeader([
+        { field: 'answer-mode', value: 'dance', reason: 'invalid-value' },
+        { field: 'transparency', value: 'flashy', reason: 'invalid-value' },
+      ]),
+    ).toBe('answer-mode=dance:invalid-value, transparency=flashy:invalid-value');
+  });
+
+  it('preserves the chorus-config-missing reason in the output', () => {
+    expect(
+      formatRejectedHeader([
+        { field: 'answer-mode', value: 'chorus', reason: 'chorus-config-missing' },
+      ]),
+    ).toBe('answer-mode=chorus:chorus-config-missing');
+  });
+});

--- a/test/pipeline-overrides.test.ts
+++ b/test/pipeline-overrides.test.ts
@@ -1,9 +1,4 @@
-import {
-  createServer,
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -79,9 +74,7 @@ function makeOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): Or
   };
 }
 
-function makeEscalationConfig(
-  overrides: Partial<EscalationConfig> = {},
-): EscalationConfig {
+function makeEscalationConfig(overrides: Partial<EscalationConfig> = {}): EscalationConfig {
   return {
     mode: 'ladder',
     ladder: ['weak-model', 'mid-model', 'strong-model'],
@@ -131,11 +124,13 @@ describe('per-request header overrides (Issue #12)', () => {
     await mock.close();
   });
 
-  function startSidecar(opts: {
-    defaultAnswerMode?: 'single' | 'chorus';
-    chorusConfig?: ChorusConfig;
-    transparencyConfig?: TransparencyConfig;
-  } = {}): void {
+  function startSidecar(
+    opts: {
+      defaultAnswerMode?: 'single' | 'chorus';
+      chorusConfig?: ChorusConfig;
+      transparencyConfig?: TransparencyConfig;
+    } = {},
+  ): void {
     sidecar = startServer(
       { port: 0, downstreamBaseUrl: mock.baseUrl },
       {

--- a/test/pipeline-overrides.test.ts
+++ b/test/pipeline-overrides.test.ts
@@ -1,0 +1,374 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer, type DecisionLogEntry, type RunningServer } from '../src/server.js';
+import type {
+  ChorusConfig,
+  EscalationConfig,
+  OrchestratorConfig,
+  SignalWeights,
+  TransparencyConfig,
+} from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirror test/pipeline-card.test.ts)
+// ---------------------------------------------------------------------------
+
+type MockHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: Buffer,
+) => void | Promise<void>;
+
+interface MockDownstream {
+  readonly baseUrl: string;
+  setHandler(handler: MockHandler): void;
+  close(): Promise<void>;
+}
+
+async function startMockDownstream(): Promise<MockDownstream> {
+  let handler: MockHandler = (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  };
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      void Promise.resolve(handler(req, res, Buffer.concat(chunks))).catch(() => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end();
+      });
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${addr.port}/v1`;
+
+  return {
+    baseUrl,
+    setHandler(h) {
+      handler = h;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function makeOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  const weights: SignalWeights = {
+    refusal: 1,
+    truncation: 1,
+    repetition: 1,
+    empty: 1,
+    tool_error: 1,
+    syntax_error: 1,
+  };
+  return {
+    threshold: 0.6,
+    weights,
+    greyBand: [0.3, 0.6],
+    ...overrides,
+  };
+}
+
+function makeEscalationConfig(
+  overrides: Partial<EscalationConfig> = {},
+): EscalationConfig {
+  return {
+    mode: 'ladder',
+    ladder: ['weak-model', 'mid-model', 'strong-model'],
+    maxDepth: 2,
+    ...overrides,
+  };
+}
+
+function buildChatCompletionBody(content: string): string {
+  return JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: 'stop',
+      },
+    ],
+  });
+}
+
+function extractContent(bodyText: string): string {
+  const obj = JSON.parse(bodyText) as {
+    choices: ReadonlyArray<{ message: { content: string } }>;
+  };
+  return obj.choices[0]!.message.content;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('per-request header overrides (Issue #12)', () => {
+  let mock: MockDownstream;
+  let sidecar: RunningServer;
+  let sidecarBaseUrl: string;
+  let logs: DecisionLogEntry[];
+
+  beforeEach(async () => {
+    mock = await startMockDownstream();
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await sidecar.close();
+    await mock.close();
+  });
+
+  function startSidecar(opts: {
+    defaultAnswerMode?: 'single' | 'chorus';
+    chorusConfig?: ChorusConfig;
+    transparencyConfig?: TransparencyConfig;
+  } = {}): void {
+    sidecar = startServer(
+      { port: 0, downstreamBaseUrl: mock.baseUrl },
+      {
+        logger: (entry) => {
+          logs.push(entry as DecisionLogEntry);
+        },
+        orchestratorConfig: makeOrchestratorConfig(),
+        escalationConfig: makeEscalationConfig(),
+        ...(opts.defaultAnswerMode !== undefined
+          ? { defaultAnswerMode: opts.defaultAnswerMode }
+          : {}),
+        ...(opts.chorusConfig !== undefined ? { chorusConfig: opts.chorusConfig } : {}),
+        ...(opts.transparencyConfig !== undefined
+          ? { transparencyConfig: opts.transparencyConfig }
+          : {}),
+      },
+    );
+    sidecarBaseUrl = `http://127.0.0.1:${sidecar.port}`;
+  }
+
+  it('transparency override: card replaces a default banner mode', async () => {
+    startSidecar({ transparencyConfig: { mode: 'banner' } });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-turbocharger-transparency': 'card',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const content = extractContent(text);
+    // Card marker shows up; banner phrasing does not.
+    expect(content).toContain('[turbocharger card]');
+    expect(content).not.toContain('A stronger model was used because');
+    expect(res.headers.get('x-turbocharger-override-rejected')).toBeNull();
+    // Log shows the override.
+    const entry = logs.at(-1);
+    expect(entry?.transparency_mode).toBe('card');
+    expect(entry?.transparency_mode_override).toBe('card');
+  });
+
+  it('transparency override: silent suppresses a default banner', async () => {
+    startSidecar({ transparencyConfig: { mode: 'banner' } });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-turbocharger-transparency': 'silent',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content).not.toContain('[turbocharger');
+    const entry = logs.at(-1);
+    expect(entry?.transparency_mode).toBe('silent');
+    expect(entry?.transparency_mode_override).toBe('silent');
+  });
+
+  it('answer-mode override: chorus is rejected when no chorus is configured', async () => {
+    startSidecar({ defaultAnswerMode: 'single' });
+
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-turbocharger-answer-mode': 'chorus',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-override-rejected')).toContain(
+      'answer-mode=chorus:chorus-config-missing',
+    );
+    // Mode header reflects the actual mode used (single).
+    expect(res.headers.get('x-turbocharger-answer-mode')).toBe('single');
+    const entry = logs.at(-1);
+    expect(entry?.answer_mode).toBe('single');
+    expect(entry?.answer_mode_override).toBeUndefined();
+    expect(entry?.override_rejected).toEqual(['answer-mode=chorus:chorus-config-missing']);
+  });
+
+  it('rejects an invalid header value tolerantly: response carries the rejection, request continues', async () => {
+    startSidecar({ transparencyConfig: { mode: 'silent' } });
+
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-turbocharger-transparency': 'flashy',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-override-rejected')).toBe(
+      'transparency=flashy:invalid-value',
+    );
+    const entry = logs.at(-1);
+    expect(entry?.transparency_mode).toBe('silent');
+    expect(entry?.transparency_mode_override).toBeUndefined();
+    expect(entry?.override_rejected).toEqual(['transparency=flashy:invalid-value']);
+  });
+
+  it('passes through requests without override headers untouched', async () => {
+    startSidecar({ transparencyConfig: { mode: 'silent' } });
+
+    mock.setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        buildChatCompletionBody(
+          'Here is a clear, complete, helpful answer with concrete details and context.',
+        ),
+      );
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-turbocharger-override-rejected')).toBeNull();
+    const entry = logs.at(-1);
+    expect(entry?.answer_mode_override).toBeUndefined();
+    expect(entry?.transparency_mode_override).toBeUndefined();
+    expect(entry?.override_rejected).toBeUndefined();
+  });
+
+  it('combines two overrides in one request', async () => {
+    startSidecar({ transparencyConfig: { mode: 'silent' } });
+
+    mock.setHandler((_req, res, body) => {
+      const parsed = JSON.parse(body.toString('utf-8')) as { model: string };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (parsed.model === 'weak-model') {
+        res.end(buildChatCompletionBody("I'm sorry, but I cannot help with that."));
+      } else {
+        res.end(
+          buildChatCompletionBody(
+            'Here is a clear, complete, helpful answer with concrete details and context.',
+          ),
+        );
+      }
+    });
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-turbocharger-answer-mode': 'single',
+        'x-turbocharger-transparency': 'banner',
+      },
+      body: JSON.stringify({
+        model: 'weak-model',
+        messages: [{ role: 'user', content: 'help me' }],
+      }),
+    });
+
+    const content = extractContent(await res.text());
+    expect(content).toContain('[turbocharger]');
+    const entry = logs.at(-1);
+    expect(entry?.answer_mode).toBe('single');
+    expect(entry?.answer_mode_override).toBe('single');
+    expect(entry?.transparency_mode).toBe('banner');
+    expect(entry?.transparency_mode_override).toBe('banner');
+  });
+});


### PR DESCRIPTION
Closes #12.

Two headers are now recognised on every request:

- `X-Turbocharger-Answer-Mode: single | chorus`
- `X-Turbocharger-Transparency: silent | banner | card`

Per ADR-0025 the design is tolerant-with-reject: invalid header values
do not fail the request. They are listed on a response-side
`x-turbocharger-override-rejected` header in the form
`field=value:reason`, comma-separated. The request continues with the
configured defaults.

A chorus answer-mode override against a deployment without a chorus
configuration is rejected with the dedicated reason
`chorus-config-missing` so monitoring tools can distinguish a client
typo from a deployment that cannot fulfil the requested mode.

The effective mode (not the default) is what surfaces on response
headers and on the structured `DecisionLogEntry` — anyone consuming
those sees the truth of what ran.

## Test count

291 → 315 passed (+18 unit + 6 integration).

## Out of scope

- A third header for escalation-mode (ladder|max) — rejected as a
  per-request knob; that's a deployment-wide cost-vs-quality
  decision, not a client choice. The same tolerant-with-reject
  machinery accommodates it without redesign if a future use case
  appears.
- README and CONFIGURATION.md updates documenting the new headers
  — better lumped into the v0.1.0 release docs (#15).