### PR TITLE
feat(release): cut v0.1.0-alpha — PR-A docs and metadata (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.0] — 2026-04-30
+
+First published alpha release. All 15 MVP issues from `PROJECT_BRIEF.md`
+§10 are merged.
+
+### Added — server and proxy
+
+- OpenAI-compatible HTTP server with pass-through proxy. Forwards
+  `POST /v1/chat/completions` byte-for-byte, streams responses without
+  buffering, preserves end-to-end headers per RFC 7230. (#2)
+
+### Added — adequacy critic
+
+- Hard-signal adequacy detectors for refusal, truncation, repetition,
+  empty/short responses, tool-error, and JSON syntax. Each detector
+  emits a continuous confidence in `[0, 1]` so the orchestrator can
+  aggregate without losing weak-but-present evidence. (#3)
+- LLM-critic adapter for small-model adequacy judgement.
+  OpenAI-compatible, locale-keyed prompts (en/de), opt-in per-request
+  budget check, tolerant JSON extraction with a discriminated result
+  so failure modes are never silently converted into a pass. (#4)
+- Orchestrator and pipeline combining hard signals (noisy-OR
+  aggregation with per-category weights) with the LLM-critic in a
+  configurable grey band into a single `pass` / `escalate` /
+  `skip-with-reason` decision. Surfaced as `X-Turbocharger-*`
+  response headers and structured log fields. (#5)
+
+### Added — escalation strategies
+
+- Ladder escalation: on `escalate`, re-queries with the next step on
+  a configured model ladder until the answer passes, the ladder is
+  exhausted, or `maxDepth` is reached. (#6)
+- Max escalation: alternative single-jump strategy that re-queries
+  directly with a configured `maxModel` rather than walking up a
+  ladder. (#7)
+
+### Added — answer modes
+
+- Top-level `AnswerMode` axis (`single` and `chorus`) parallel to but
+  separate from the escalation strategies. (#8, ADR-0021)
+- Chorus dispatch to an external multi-model consensus endpoint, with
+  classified errors (`endpoint_not_set`, `unreachable`, `timeout`,
+  `non_ok_status`) and no silent fallback. The orchestrator does not
+  run in chorus mode — chorus carries its own meta-adequacy logic.
+
+### Added — transparency
+
+- Banner mode: single-line localized annotation prepended to the
+  assistant content when escalation or skip-with-reason happened in
+  single mode. Opt-in via `transparencyConfig.mode = 'banner'`;
+  technical default is `silent`. (#9, ADR-0022)
+- Card mode: opt-in structured Markdown card with the full decision
+  context (initial model, decision kind, signals, aggregate, escalation
+  path, outcome). Locale-aware structural labels (en/de); values stay
+  English. (#10, ADR-0023)
+
+### Added — configuration
+
+- Zod-validated configuration loader accepting YAML or JSON files via
+  `TURBOCHARGER_CONFIG`, environment-variable overrides via
+  `TURBOCHARGER_*` (`__` for nesting, `,` for arrays), and hard-coded
+  defaults. Validation errors are aggregated with full dotted-path
+  context so operators see every misconfiguration in one error
+  message. (#11, ADR-0024)
+- Per-request header overrides for answer mode and transparency mode
+  (`X-Turbocharger-Answer-Mode`, `X-Turbocharger-Transparency`),
+  layered on top of the static configuration. Invalid values are
+  rejected and reported on a `x-turbocharger-override-rejected`
+  response header rather than silently falling through. (#12, ADR-0025)
+
+### Added — documentation
+
+- README, `docs/COMPARISON.md`, `docs/CONFIGURATION.md`,
+  `docs/ARCHITECTURE.md`, and `CONTRIBUTING.md` brought to
+  release-ready state, including the `Two answer modes` section and
+  the configuration overview. (#13, #14)
+- `CHANGELOG.md` (this file) and `docs/RELEASING.md` (release runbook)
+  added as part of the v0.1.0-alpha cut. (#15)
+
+### Architecture decisions
+
+24 ADRs documenting the design — see
+[`docs/DECISIONS.md`](./docs/DECISIONS.md). Notable for users:
+
+- **ADR-0021** — chorus reclassified from escalation strategy to a
+  parallel `AnswerMode`. Chorus is a user-selected paradigm for
+  multi-model consensus, not a reactive fallback.
+- **ADR-0022** — banner phrasing is deliberately vague
+  ("looked incomplete" rather than "was wrong") because the adequacy
+  critic flags signals, not proven inadequacy.
+- **ADR-0024** — environment overrides file overrides defaults; the
+  loader follows 12-factor precedence and works with immutable
+  container images.
+
+### Out of scope for v0.1.0-alpha
+
+- **Native OpenClaw plugin integration** is tracked as #22 for a later
+  release. v0.1.0-alpha ships as a standalone OpenAI-compatible HTTP
+  sidecar; OpenClaw users can configure it as a custom provider URL.
+  When #22 lands, `openclaw plugins install
+  @steggl/openclaw-turbocharger` will work end-to-end and the project
+  will be submitted to the openclaw/docs `plugins/community.md` listing.
+- **Streaming response transparency annotations** (per ADR-0013).
+  Banner and card mode apply only to non-streaming responses.
+- **Chorus-mode transparency** is intentionally absent (per ADR-0021).
+  Chorus carries its own transparency via the minority reports of the
+  chorus endpoint; layering banner or card on top would be redundant
+  noise.
+
+[Unreleased]: https://github.com/Steggl/openclaw-turbocharger/compare/v0.1.0-alpha.0...HEAD
+[0.1.0-alpha.0]: https://github.com/Steggl/openclaw-turbocharger/releases/tag/v0.1.0-alpha.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ First published alpha release. All 15 MVP issues from `PROJECT_BRIEF.md`
   release. v0.1.0-alpha ships as a standalone OpenAI-compatible HTTP
   sidecar; OpenClaw users can configure it as a custom provider URL.
   When #22 lands, `openclaw plugins install
-  @steggl/openclaw-turbocharger` will work end-to-end and the project
+@steggl/openclaw-turbocharger` will work end-to-end and the project
   will be submitted to the openclaw/docs `plugins/community.md` listing.
 - **Streaming response transparency annotations** (per ADR-0013).
   Banner and card mode apply only to non-streaming responses.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 > A sidecar that decides between running one model carefully and asking
 > several at once. For OpenClaw and any OpenAI-compatible client.
 
-**Status:** in-progress implementation. 11 of 15 MVP issues merged. The
-proxy, adequacy detectors, LLM-critic, orchestrator, pipeline, ladder
-escalation, max escalation, chorus dispatch stub, the transparency
-banner and card, and the Zod-validated config loader are all in place.
-Per-request overrides, the doc finalization round, and the first
-published release are still pending. No published release yet.
+**Status:** all 15 MVP issues merged. The proxy, adequacy detectors,
+LLM-critic, orchestrator, pipeline, ladder and max escalation,
+chorus dispatch, transparency banner and card, the Zod-validated
+config loader, and per-request header overrides are all in place.
+v0.1.0-alpha is being cut — see [`CHANGELOG.md`](./CHANGELOG.md)
+for the release notes and [`docs/RELEASING.md`](./docs/RELEASING.md)
+for how the release is assembled.
 
 openclaw-turbocharger fills the gap between "one cheap model for everything"
 and "one expensive model for everything." It runs whichever model you
@@ -99,6 +100,19 @@ so far, in order:
     misconfiguration in one error message. See
     [`docs/CONFIGURATION.md`](./docs/CONFIGURATION.md) and
     [ADR-0024](./docs/DECISIONS.md).
+12. **#12 `config:per-request-override`** — header-based per-request
+    overrides for answer mode and transparency mode
+    (`X-Turbocharger-Answer-Mode`, `X-Turbocharger-Transparency`),
+    layered on top of the static configuration. Invalid values are
+    rejected and reported on a `x-turbocharger-override-rejected`
+    response header rather than silently falling through. See
+    [ADR-0025](./docs/DECISIONS.md).
+13. **#13 + #14 `docs:readme` + `docs:comparison`** — full README,
+    `docs/COMPARISON.md`, `docs/CONFIGURATION.md`,
+    `docs/ARCHITECTURE.md`, and `CONTRIBUTING.md` polish to
+    release-ready state, including the `Two answer modes` section
+    and the configuration overview. Documentation tracks the code
+    rather than trailing it.
 
 ## Transparency
 
@@ -153,13 +167,22 @@ banner and card respectively, and
 [`docs/CONFIGURATION.md`](./docs/CONFIGURATION.md) for the
 configuration shape.
 
-## What lands next
+## What's next
 
-1. **#12 `config:per-request-override`** — header-based per-request
-   overrides (`X-Turbocharger-Answer-Mode`, `X-Turbocharger-Transparency`,
-   …) on top of the static configuration loaded from env and file.
-2. **#15 `release:v0.1.0-alpha`** — first published version. Brings
-   the npm package, the ClawHub manifest, and a Docker image.
+The MVP is complete. Post-v0.1.0-alpha work is tracked in the issue
+tracker on GitHub. Notable items:
+
+- **#22 `plugin-sdk`** — native OpenClaw plugin adapter and an entry
+  on `plugins/community.md`. v0.1.0-alpha ships as a standalone
+  OpenAI-compatible HTTP sidecar; OpenClaw users can already
+  configure it as a custom provider URL. #22 adds first-class plugin
+  integration via the OpenClaw plugin SDK so that
+  `openclaw plugins install @steggl/openclaw-turbocharger` works
+  end-to-end.
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for the v0.1.0-alpha.0 release
+notes and [`docs/RELEASING.md`](./docs/RELEASING.md) for how releases
+are assembled.
 
 ## Configuration
 
@@ -235,13 +258,13 @@ YAML/JSON-Datei (Pfad aus `TURBOCHARGER_CONFIG`); env-Werte
 überschreiben Datei-Werte. Validierungsfehler werden gesammelt und
 mit vollem Pfad-Kontext gemeldet.
 
-Stand: laufende Implementierung, 11 von 15 MVP-Issues gemerged.
-Proxy, Adäquanz-Detektoren, LLM-Kritiker, Orchestrator, Pipeline,
-Ladder- und Max-Eskalation, Chorus-Dispatch, Banner- und
-Card-Transparenz sowie der Zod-validierte Config-Loader sind
-fertig. Per-Request-Overrides, finale Doku-Runde und das erste
-Release stehen noch aus. Es gibt noch kein veröffentlichtes
-Release.
+Stand: alle 15 MVP-Issues gemerged. Proxy, Adäquanz-Detektoren,
+LLM-Kritiker, Orchestrator, Pipeline, Ladder- und Max-Eskalation,
+Chorus-Dispatch, Banner- und Card-Transparenz, der Zod-validierte
+Config-Loader und Per-Request-Header-Overrides sind alle fertig.
+v0.1.0-alpha wird vorbereitet — siehe [`CHANGELOG.md`](./CHANGELOG.md)
+für die Release-Notes und [`docs/RELEASING.md`](./docs/RELEASING.md)
+für den Release-Ablauf.
 
 ## License
 

--- a/clawhub.json
+++ b/clawhub.json
@@ -1,4 +1,0 @@
-{
-  "_note_1": "PLACEHOLDER MANIFEST — populated for real in issue #15 (release v0.1.0-alpha).",
-  "_note_2": "Schema source not confirmed. No primary source for the ClawHub registry manifest format was verified during scaffold. Will verify in issue #15 before publishing."
-}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,57 @@
+# Releasing
+
+How an `openclaw-turbocharger` release is assembled and published.
+
+## Status
+
+Stub — landed as part of PR-A of issue #15. Will be expanded in PR-C
+once the npm publish plumbing and Docker image build are wired up.
+Below is the planned sequence; the final document will include exact
+commands, prerequisite checks, and rollback steps for each step.
+
+## Planned release sequence
+
+1. **Prerequisites.** `pnpm check` is green on `main`. The
+   `CHANGELOG.md` `[Unreleased]` section has been promoted to the
+   target version with today's date and contains the actual changes
+   shipping in this release. The `package.json` `version` field
+   matches the version about to be released.
+2. **Tag.** `git tag -a vX.Y.Z -m 'release X.Y.Z'` from `main` and
+   `git push origin vX.Y.Z`. Tags are immutable once pushed; a botched
+   tag is corrected by tagging a successor (`vX.Y.Z+1`), not by
+   force-pushing the old one.
+3. **GitHub Release.** Created from the tag, with notes copied from
+   the `CHANGELOG.md` entry. The "Pre-release" flag is set for any
+   `*-alpha`, `*-beta`, or `*-rc` version. Auto-generated release
+   notes are appended below the manual notes for completeness, not
+   used as a substitute.
+4. **npm publish.** `pnpm publish --access public` with the
+   appropriate dist-tag. Pre-releases use `--tag alpha` (or `beta`,
+   `rc`) so that `npm install @steggl/openclaw-turbocharger` keeps
+   resolving to the latest stable when one exists. The first
+   non-pre-release version will set the `latest` dist-tag.
+5. **Docker image.** `docker build` from the repository root, tagged
+   as `ghcr.io/steggl/openclaw-turbocharger:X.Y.Z`. The `:latest` tag
+   is only pushed for stable releases; pre-releases use only the
+   explicit version tag.
+
+## Versioning policy
+
+- `0.x.y` while pre-MVP and during the alpha series. SemVer is
+  applied; breaking changes are tolerated between `0.x` minors.
+- `1.0.0` once the public API has stabilized. No firm date — driven
+  by adoption and feedback rather than calendar.
+- Pre-release tags follow SemVer 2.0.0: `-alpha.N`, `-beta.N`,
+  `-rc.N`. The pre-release counter starts at `0`
+  (`0.1.0-alpha.0`, `0.1.0-alpha.1`, …) so that the first published
+  pre-release does not look like an afterthought.
+
+## Out of scope for this stub
+
+- **Exact `pnpm publish` invocation and `npm` access setup.** Lands
+  with PR-B (npm plumbing) of issue #15.
+- **Exact `Dockerfile` build context, image base, and registry push
+  commands.** Lands with PR-C (Docker plumbing) of issue #15.
+- **Automated release workflow** (GitHub Actions on tag push).
+  Optional follow-up after the manual release path is documented and
+  proven on at least one real release.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,5 @@
 {
-  "_note_1": "PLACEHOLDER MANIFEST — populated for real in issue #15 (release v0.1.0-alpha).",
-  "_note_2": "Schema source not confirmed. Web search during scaffold surfaced a consistent field pattern (required: `id`, `configSchema`; optional: `kind`, `channels`, `providers`, `skills`, `name`, `description`) across several doc mirrors, but no single primary source (e.g. an official github.com/openclaw repo) was verified. Will verify in issue #15 before publishing.",
-  "_note_3": "Candidate sources to re-check: https://docs.openclaw.ai/tools/plugin ; deepwiki.com/openclaw/docs ; docs.claw.so/engine/plugins/manifest .",
-  "id": "turbocharger-placeholder",
-  "configSchema": {}
+  "_note_1": "TODO marker — not a real OpenClaw plugin manifest. v0.1.0-alpha ships openclaw-turbocharger as a standalone OpenAI-compatible HTTP sidecar; the runtime adapter required for `openclaw plugins install` is not implemented in this version.",
+  "_note_2": "Tracked as issue #22. The verified plugin manifest schema is documented at https://docs.openclaw.ai/plugins/manifest.md (required: `id`, `configSchema`; optional: `kind`, `channels`, `providers`, `skills`, `name`, `description`, `uiHints`, `version`).",
+  "_note_3": "OpenClaw users today: configure turbocharger as a custom OpenAI-compatible provider pointing at the sidecar's HTTP port. See README.md `Configuration` section."
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steggl/openclaw-turbocharger",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "Reactive model escalation sidecar for OpenClaw and any OpenAI-compatible client. Runs a default model first, escalates to a stronger one only when adequacy signals say it didn't hold up, and surfaces the escalation to the user.",
   "keywords": [
     "openclaw",


### PR DESCRIPTION
First of three PRs that comprise issue #15.

This PR brings the repository metadata to v0.1.0-alpha state and lays
out the changelog and release runbook. The npm publish plumbing
(PR-B) and Docker image (PR-C) follow as separate PRs in the same
issue. The actual tag, GitHub Release, npm publish, and Docker push
happen after all three PRs land on main.

## What

- `package.json`: version `0.0.1` → `0.1.0-alpha.0`. The npm-relevant
  fields (name, main, types, exports, files, repository, homepage,
  bugs, engines, packageManager) are already in place from #11.
- `README.md`: status block describes "all 15 MVP issues merged,
  v0.1.0-alpha being cut"; "What has landed" extended with
  #12 (per-request overrides) and #13+#14 (docs polish, combined
  PR); "What lands next" replaced with "What's next" pointing at
  backlog issue #22 (OpenClaw plugin SDK adapter), the new
  CHANGELOG, and the new RELEASING runbook. Kurzfassung (DE)
  mirrored.
- `CHANGELOG.md`: new file. Keep a Changelog 1.1.0 format. Documents
  v0.1.0-alpha.0 with all 15 issues by category (server/proxy,
  adequacy critic, escalation, answer modes, transparency,
  configuration, documentation), 24 ADRs summarized for users with
  the most user-visible three highlighted, plus an "Out of scope"
  section noting OpenClaw plugin SDK integration (#22), streaming
  response transparency (ADR-0013), and chorus-mode transparency
  (ADR-0021) are intentional non-goals for this release.
- `docs/RELEASING.md`: new file. Stub describing the planned five-
  step release sequence (prerequisites, tag, GitHub Release, npm
  publish, Docker image), the versioning policy, and explicit
  out-of-scope items deferred to PR-B (npm) and PR-C (Docker).
- `clawhub.json`: deleted. Was an unverified spec from the scaffold
  phase. Verified against `https://docs.openclaw.ai/plugins/manifest.md`
  and `https://docs.openclaw.ai/plugins/community.md`: the OpenClaw
  ecosystem only uses `openclaw.plugin.json`, and the community
  registry is a PR against openclaw/docs adding a markdown bullet,
  not a separate manifest file.
- `openclaw.plugin.json`: rewritten as a TODO marker pointing at #22.
  The `id` and `configSchema` fields are intentionally absent so
  anyone trying to use this as a real manifest gets a clear
  validation error pointing at the file. The verified plugin
  manifest schema will be used when #22 implements the runtime
  adapter.
- `chore` follow-up: prettier reformatted one continuation line
  in CHANGELOG.md. Whitespace only, no content change.

## Verification

`pnpm check` green locally — 315 passed | 3 todo, format clean,
lint clean, typecheck clean, build succeeds (53.53 KB / 19.34 KB
types). No code, test, or config changes — documentation and
metadata only.

## Out of scope (this PR)

- npm `prepublishOnly` script and `npm publish --dry-run`
  verification — PR-B of #15.
- `Dockerfile` and Docker build verification — PR-C of #15.
- Tag, GitHub Release, npm publish, Docker push — happens after
  all three PRs land.
- OpenClaw plugin SDK integration — tracked as #22, separate
  post-MVP work.