### PR TITLE
feat(release): npm publish plumbing — PR-B (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,34 @@ See [`CHANGELOG.md`](./CHANGELOG.md) for the v0.1.0-alpha.0 release
 notes and [`docs/RELEASING.md`](./docs/RELEASING.md) for how releases
 are assembled.
 
+## Install
+
+`openclaw-turbocharger` is published on npm as a scoped package and
+installs a single binary, `openclaw-turbocharger`, that runs the
+sidecar.
+
+Run it directly without installing globally:
+
+```bash
+TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:11434/v1 \
+  npx @steggl/openclaw-turbocharger
+```
+
+Or install once and use the `openclaw-turbocharger` command:
+
+```bash
+npm install -g @steggl/openclaw-turbocharger
+
+TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:11434/v1 \
+  openclaw-turbocharger
+```
+
+The package is also importable from a Node application for embedded
+use; see the named exports of `@steggl/openclaw-turbocharger`.
+
+For Docker deployments, see [`docs/RELEASING.md`](./docs/RELEASING.md)
+once the Docker image is published in PR-C of issue #15.
+
 ## Configuration
 
 The sidecar reads configuration from three sources, in order of
@@ -265,6 +293,10 @@ Config-Loader und Per-Request-Header-Overrides sind alle fertig.
 v0.1.0-alpha wird vorbereitet — siehe [`CHANGELOG.md`](./CHANGELOG.md)
 für die Release-Notes und [`docs/RELEASING.md`](./docs/RELEASING.md)
 für den Release-Ablauf.
+
+Installation: `npx @steggl/openclaw-turbocharger` oder
+`npm install -g @steggl/openclaw-turbocharger` und dann
+`openclaw-turbocharger` aufrufen.
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,10 +4,11 @@ How an `openclaw-turbocharger` release is assembled and published.
 
 ## Status
 
-Stub — landed as part of PR-A of issue #15. Will be expanded in PR-C
-once the npm publish plumbing and Docker image build are wired up.
-Below is the planned sequence; the final document will include exact
-commands, prerequisite checks, and rollback steps for each step.
+PR-A introduced this runbook with the planned five-step sequence.
+PR-B expanded step 4 (npm publish) with the verified flow,
+including the `prepublishOnly` hook and the `pnpm pack --dry-run`
+pre-flight. The Docker section will be expanded in PR-C once the
+image build is wired up.
 
 ## Planned release sequence
 
@@ -25,11 +26,34 @@ commands, prerequisite checks, and rollback steps for each step.
    `*-alpha`, `*-beta`, or `*-rc` version. Auto-generated release
    notes are appended below the manual notes for completeness, not
    used as a substitute.
-4. **npm publish.** `pnpm publish --access public` with the
-   appropriate dist-tag. Pre-releases use `--tag alpha` (or `beta`,
-   `rc`) so that `npm install @steggl/openclaw-turbocharger` keeps
-   resolving to the latest stable when one exists. The first
-   non-pre-release version will set the `latest` dist-tag.
+4. **npm publish.** Pre-flight: verify the tarball contents.
+
+   ```bash
+   pnpm pack --dry-run
+   ```
+
+   Should match the `files` allowlist in `package.json`: `dist/`,
+   `README.md`, `LICENSE`, `CHANGELOG.md`. Any other path appearing
+   in the dry-run output is a misconfiguration of the allowlist
+   and should be fixed before publishing.
+
+   Publish:
+
+   ```bash
+   pnpm publish --tag alpha
+   ```
+
+   `--tag alpha` keeps `npm install @steggl/openclaw-turbocharger`
+   resolving to the latest stable when one exists. Without `--tag`,
+   npm uses `latest` by default; the first non-pre-release version
+   will be published without `--tag` so `latest` claims it.
+
+   The `prepublishOnly` script in `package.json` runs `pnpm check:ci`
+   first (lint, format check, typecheck, test, build); if anything
+   is broken, no artifact is pushed to npm. Public access is
+   declared via `publishConfig.access` in `package.json`, so the
+   scoped `@steggl/...` namespace publishes publicly without
+   `--access public` on every invocation.
 5. **Docker image.** `docker build` from the repository root, tagged
    as `ghcr.io/steggl/openclaw-turbocharger:X.Y.Z`. The `:latest` tag
    is only pushed for stable releases; pre-releases use only the
@@ -48,8 +72,6 @@ commands, prerequisite checks, and rollback steps for each step.
 
 ## Out of scope for this stub
 
-- **Exact `pnpm publish` invocation and `npm` access setup.** Lands
-  with PR-B (npm plumbing) of issue #15.
 - **Exact `Dockerfile` build context, image base, and registry push
   commands.** Lands with PR-C (Docker plumbing) of issue #15.
 - **Automated release workflow** (GitHub Actions on tag push).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ How an `openclaw-turbocharger` release is assembled and published.
 
 PR-A introduced this runbook with the planned five-step sequence.
 PR-B expanded step 4 (npm publish) with the verified flow,
-including the `prepublishOnly` hook and the `pnpm pack --dry-run`
+including the `prepublishOnly` hook and the `npm pack --dry-run`
 pre-flight. The Docker section will be expanded in PR-C once the
 image build is wired up.
 
@@ -29,7 +29,7 @@ image build is wired up.
 4. **npm publish.** Pre-flight: verify the tarball contents.
 
    ```bash
-   pnpm pack --dry-run
+   npm pack --dry-run
    ```
 
    Should match the `files` allowlist in `package.json`: `dist/`,
@@ -54,6 +54,7 @@ image build is wired up.
    declared via `publishConfig.access` in `package.json`, so the
    scoped `@steggl/...` namespace publishes publicly without
    `--access public` on every invocation.
+
 5. **Docker image.** `docker build` from the repository root, tagged
    as `ghcr.io/steggl/openclaw-turbocharger:X.Y.Z`. The `:latest` tag
    is only pushed for stable releases; pre-releases use only the

--- a/package.json
+++ b/package.json
@@ -36,11 +36,18 @@
       "import": "./dist/server.js"
     }
   },
+  "bin": {
+    "openclaw-turbocharger": "./dist/server.js"
+  },
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
@@ -52,7 +59,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check": "pnpm format && pnpm lint:fix && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build",
-    "check:ci": "pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build"
+    "check:ci": "pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build",
+    "prepublishOnly": "pnpm check:ci"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   minify: false,
+  // Shebang for direct CLI invocation when installed via `npm install -g`
+  // or `npx`. The `bin` field in package.json points at this output.
+  banner: { js: '#!/usr/bin/env node' },
   // Declarations are generated using the build-specific tsconfig, which sets
   // noEmit: false and declaration: true. The root tsconfig.json stays
   // emit-less for editor / `tsc --noEmit` typechecking. See


### PR DESCRIPTION
Second of three PRs that comprise issue #15. Wires up the npm
publishing flow now that PR-A has the version, changelog, and runbook
in place. PR-C will follow with the Docker image. The actual tag,
GitHub Release, npm publish, and Docker push happen after all three
PRs land on main.

## What

- `package.json`:
  - `scripts.prepublishOnly: 'pnpm check:ci'` so a broken local
    state can never reach npm.
  - `publishConfig.access: 'public'` for the scoped `@steggl/*`
    namespace.
  - `bin: { 'openclaw-turbocharger': './dist/server.js' }` so
    `npx @steggl/openclaw-turbocharger` and the `openclaw-turbocharger`
    command (after global install) work as direct CLI entries.
  - `files`: added `CHANGELOG.md` so npm-registry visitors and
    `npm view` see release notes alongside the README.

- `tsup.config.ts`: `banner: { js: '#!/usr/bin/env node' }` so the
  built `dist/server.js` is directly executable. Verified
  `head -1 dist/server.js` shows the shebang.

- `docs/RELEASING.md`: step 4 (npm publish) expanded with the
  verified pre-flight (`npm pack --dry-run` — note: pnpm has no
  `pack --dry-run` equivalent), the publish command with the alpha
  dist-tag, and how `prepublishOnly` plus `publishConfig.access`
  remove per-publish flags. Status section updated.

- `README.md`: new "Install" section between "What's next" and
  "Configuration" showing `npx` and global-install paths.
  Kurzfassung (DE) gets a short matching install paragraph.

## Verification

- `pnpm check`: green (315 passed | 3 todo, build clean,
  `dist/server.js` 53.55 kB with shebang as line 1).
- `npm pack --dry-run`: 7 files in tarball (`package.json`,
  `README.md`, `LICENSE`, `CHANGELOG.md`, `dist/server.js`,
  `dist/server.d.ts`, `dist/server.js.map`), 75.1 kB packed,
  277.2 kB unpacked. Matches the `files` allowlist plus npm's
  always-included `package.json`.

## Commits

Two: feat (the main change) and chore (prettier blank line +
fixed `pnpm` → `npm` in pack-dry-run wording).

## Out of scope (this PR)

- `Dockerfile` and Docker build verification — PR-C of #15.
- Tag, GitHub Release, npm publish, Docker push — happens after
  all three PRs land.
- Auto-publish via GitHub Actions — deferred per scope decision.
- OpenClaw plugin SDK integration — tracked as #22.