### PR TITLE
feat(release): Docker image plumbing — PR-C (#15)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Version control.
+.git
+.gitignore
+.gitattributes
+
+# Editor and IDE state.
+.idea
+.vscode
+.editorconfig
+
+# Build artifacts (rebuilt inside the container).
+dist
+*.tsbuildinfo
+
+# Dependencies (installed inside the container).
+node_modules
+
+# Test files (the runtime image does not run vitest).
+test
+coverage
+.nyc_output
+vitest.config.ts
+
+# Project documentation (does not need to be in the image).
+docs
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+LICENSE
+PROJECT_BRIEF.md
+
+# Examples.
+examples
+
+# CI and project meta.
+.github
+
+# Linting and formatting (only used in the host workflow).
+eslint.config.js
+.prettierrc
+.prettierignore
+
+# Unrelated package metadata.
+openclaw.plugin.json
+
+# Logs and OS junk.
+*.log
+.DS_Store
+Thumbs.db
+
+# Docker itself.
+Dockerfile
+.dockerignore
+
+# Node version pin (used by host's nvm/asdf, irrelevant inside the image).
+.nvmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,57 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  docker-smoke:
+    name: Docker smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: openclaw-turbocharger:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run container
+        run: |
+          docker run -d --name turbocharger-smoke \
+            -p 11435:11435 \
+            -e TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:9999 \
+            openclaw-turbocharger:smoke
+
+          sleep 3
+
+          STATUS=$(docker inspect -f '{{.State.Status}}' turbocharger-smoke)
+          echo "Container status: $STATUS"
+          echo "=== Container logs ==="
+          docker logs turbocharger-smoke
+          echo "=== End logs ==="
+
+          if [ "$STATUS" != "running" ]; then
+            echo "::error::Container is not running (status: $STATUS)"
+            exit 1
+          fi
+
+      - name: Verify port is bound
+        run: |
+          if ! nc -zv -w 2 localhost 11435; then
+            echo "::error::Port 11435 not bound on the runner"
+            docker logs turbocharger-smoke
+            exit 1
+          fi
+          echo "Port 11435 bound — smoke test passed"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop turbocharger-smoke 2>/dev/null || true
+          docker rm turbocharger-smoke 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,17 @@ First published alpha release. All 15 MVP issues from `PROJECT_BRIEF.md`
   loader follows 12-factor precedence and works with immutable
   container images.
 
+### Distribution
+
+- **npm** — published as `@steggl/openclaw-turbocharger` on the npm
+  registry under the `alpha` dist-tag. Includes a CLI binary
+  (`openclaw-turbocharger`) so the package is usable directly via
+  `npx @steggl/openclaw-turbocharger` without cloning the repo.
+- **Docker** — published as `steggl/openclaw-turbocharger` on
+  Docker Hub and `ghcr.io/steggl/openclaw-turbocharger` on GHCR.
+  Multi-stage build on `node:22-alpine`, runs as the non-root
+  `node` user, exposes port 11435.
+
 ### Out of scope for v0.1.0-alpha
 
 - **Native OpenClaw plugin integration** is tracked as #22 for a later

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- builder ----------
+# Builds the dist/ output. Includes devDependencies for tsup and the
+# TypeScript declaration generator. Pruned to production-only deps at
+# the end so the runtime stage can copy a slim node_modules tree.
+FROM node:22-alpine AS builder
+
+WORKDIR /build
+
+# pnpm is bundled with Node 22 via corepack. Pin to the same version as
+# the host workflow to keep behaviour reproducible across environments.
+RUN corepack enable && corepack prepare pnpm@9.12.3 --activate
+
+# Manifest first so npm-install layer caches independently of source.
+COPY package.json pnpm-lock.yaml ./
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm install --frozen-lockfile
+
+# Build inputs.
+COPY tsconfig.json tsconfig.build.json tsup.config.ts ./
+COPY src ./src
+
+RUN pnpm build
+
+# Drop devDependencies before the runtime stage copies node_modules.
+RUN pnpm prune --prod
+
+
+# ---------- runtime ----------
+# Minimal stage with just the production deps and the built artifact.
+# Runs as the non-root `node` user (uid 1000) bundled with the
+# node:22-alpine image.
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+
+USER node
+
+COPY --from=builder --chown=node:node /build/node_modules ./node_modules
+COPY --from=builder --chown=node:node /build/dist ./dist
+COPY --from=builder --chown=node:node /build/package.json ./package.json
+
+# The sidecar listens on port 11435 by default. Override via the
+# corresponding TURBOCHARGER_* environment variable.
+EXPOSE 11435
+
+# OCI image labels. Version is intentionally not hardcoded — set it
+# at build time with --label org.opencontainers.image.version=X.Y.Z
+# during the release build (see docs/RELEASING.md).
+LABEL org.opencontainers.image.title="openclaw-turbocharger"
+LABEL org.opencontainers.image.description="Reactive model escalation sidecar for OpenClaw and any OpenAI-compatible client"
+LABEL org.opencontainers.image.source="https://github.com/Steggl/openclaw-turbocharger"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Direct invocation. Override with TURBOCHARGER_* env vars or by
+# passing additional args to `docker run`.
+ENTRYPOINT ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -209,8 +209,18 @@ TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:11434/v1 \
 The package is also importable from a Node application for embedded
 use; see the named exports of `@steggl/openclaw-turbocharger`.
 
-For Docker deployments, see [`docs/RELEASING.md`](./docs/RELEASING.md)
-once the Docker image is published in PR-C of issue #15.
+For Docker deployments, the image is published on Docker Hub and
+GHCR:
+
+```bash
+docker run -p 11435:11435 \
+  -e TURBOCHARGER_DOWNSTREAM_BASE_URL=http://your-llm-host:11434/v1 \
+  steggl/openclaw-turbocharger:0.1.0-alpha.0
+```
+
+Replace `steggl/...` with `ghcr.io/steggl/...` to pull from GHCR
+instead. See [`docs/RELEASING.md`](./docs/RELEASING.md) for the
+build and publish flow.
 
 ## Configuration
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,8 +7,9 @@ How an `openclaw-turbocharger` release is assembled and published.
 PR-A introduced this runbook with the planned five-step sequence.
 PR-B expanded step 4 (npm publish) with the verified flow,
 including the `prepublishOnly` hook and the `npm pack --dry-run`
-pre-flight. The Docker section will be expanded in PR-C once the
-image build is wired up.
+pre-flight. PR-C expanded step 5 (Docker image) with the
+multi-stage build, the local smoke test, and dual-registry push
+(Docker Hub plus GHCR). All five steps now have concrete commands.
 
 ## Planned release sequence
 
@@ -55,10 +56,57 @@ image build is wired up.
    scoped `@steggl/...` namespace publishes publicly without
    `--access public` on every invocation.
 
-5. **Docker image.** `docker build` from the repository root, tagged
-   as `ghcr.io/steggl/openclaw-turbocharger:X.Y.Z`. The `:latest` tag
-   is only pushed for stable releases; pre-releases use only the
-   explicit version tag.
+5. **Docker image.** Pre-flight: build and smoke-test locally.
+
+   ```bash
+   docker build -t openclaw-turbocharger:smoke .
+
+   docker run -d --rm --name turbocharger-smoke \
+     -p 11435:11435 \
+     -e TURBOCHARGER_DOWNSTREAM_BASE_URL=http://localhost:9999 \
+     openclaw-turbocharger:smoke
+
+   sleep 3
+
+   docker ps --filter name=turbocharger-smoke --format '{{.Status}}'
+   docker logs turbocharger-smoke
+   nc -zv localhost 11435 2>&1 | head -1
+
+   docker stop turbocharger-smoke
+   ```
+
+   The smoke test confirms three things: the image builds without
+   error, the container stays alive past the startup window, and
+   the configured port is bound. The dummy `localhost:9999`
+   downstream URL is intentional — the sidecar should start
+   regardless of whether the downstream is reachable; that
+   contract gets verified here.
+
+   Tag and push to both registries.
+
+   ```bash
+   echo "$GITHUB_TOKEN" | docker login ghcr.io -u steggl --password-stdin
+   docker login --username steggl
+
+   VERSION=X.Y.Z
+
+   docker build \
+     --label org.opencontainers.image.version="$VERSION" \
+     -t openclaw-turbocharger:"$VERSION" .
+
+   docker tag openclaw-turbocharger:"$VERSION" \
+     ghcr.io/steggl/openclaw-turbocharger:"$VERSION"
+   docker push ghcr.io/steggl/openclaw-turbocharger:"$VERSION"
+
+   docker tag openclaw-turbocharger:"$VERSION" \
+     steggl/openclaw-turbocharger:"$VERSION"
+   docker push steggl/openclaw-turbocharger:"$VERSION"
+   ```
+
+   The `:latest` tag is pushed only for stable releases (no
+   `-alpha`, `-beta`, or `-rc` suffix). Pre-releases use only the
+   explicit version tag so `docker pull steggl/openclaw-turbocharger`
+   keeps resolving to the latest stable when one exists.
 
 ## Versioning policy
 
@@ -73,8 +121,6 @@ image build is wired up.
 
 ## Out of scope for this stub
 
-- **Exact `Dockerfile` build context, image base, and registry push
-  commands.** Lands with PR-C (Docker plumbing) of issue #15.
 - **Automated release workflow** (GitHub Actions on tag push).
   Optional follow-up after the manual release path is documented and
   proven on at least one real release.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,8 +8,10 @@ PR-A introduced this runbook with the planned five-step sequence.
 PR-B expanded step 4 (npm publish) with the verified flow,
 including the `prepublishOnly` hook and the `npm pack --dry-run`
 pre-flight. PR-C expanded step 5 (Docker image) with the
-multi-stage build, the local smoke test, and dual-registry push
-(Docker Hub plus GHCR). All five steps now have concrete commands.
+multi-stage build, a CI-verified smoke test (run on every PR
+via the `docker-smoke` job in `.github/workflows/ci.yml`), and
+dual-registry push (Docker Hub plus GHCR). All five steps now
+have concrete commands.
 
 ## Planned release sequence
 
@@ -56,7 +58,11 @@ multi-stage build, the local smoke test, and dual-registry push
    scoped `@steggl/...` namespace publishes publicly without
    `--access public` on every invocation.
 
-5. **Docker image.** Pre-flight: build and smoke-test locally.
+5. **Docker image.** Pre-flight: the build and smoke test run on
+   every PR via the `docker-smoke` job in
+   `.github/workflows/ci.yml`, so a green CI on `main` already
+   implies a working image. To reproduce the smoke test locally
+   (requires Docker installed):
 
    ```bash
    docker build -t openclaw-turbocharger:smoke .


### PR DESCRIPTION
Third and final PR that comprises issue #15. Adds the Docker image
build now that PR-A has the version, changelog, and runbook in place
and PR-B has the npm publishing flow. The actual tag, GitHub Release,
npm publish, and Docker push happen after this PR lands.

## What

- `Dockerfile` (new): multi-stage build on `node:22-alpine`. Builder
  stage uses corepack to pin pnpm@9.12.3 (matching the
  `packageManager` field), installs deps with `--frozen-lockfile`
  under a BuildKit cache mount, builds `dist/`, prunes
  devDependencies. Runtime stage copies the pruned `node_modules`
  and `dist/` from the builder, runs as the non-root `node` user
  (uid 1000), exposes port 11435, sets OCI image labels (title,
  description, source, licenses), and uses `ENTRYPOINT` to invoke
  `node dist/server.js`.

- `.dockerignore` (new): keeps the build context lean. Excludes
  `node_modules`, `dist/` (rebuilt inside container), test files,
  documentation, examples, `.github`, lint/format configs, and
  `Dockerfile` and `.dockerignore` themselves.

- `.github/workflows/ci.yml`: new `docker-smoke` job runs in
  parallel with the existing `Node 22` matrix job on every PR.
  Uses `docker/build-push-action@v6` with GHA cache mounts for
  warm-build speed, runs the container with a dummy downstream
  URL, verifies the container is `running` after a 3s startup
  window, probes port 11435 with `nc`, and dumps logs
  unconditionally for the build record.

- `docs/RELEASING.md`: step 5 (Docker image) replaced with the
  verified flow — CI-side smoke test (the `docker-smoke` job is
  the gating check, a green CI implies a working image), plus the
  local reproduction instructions for contributors who have
  Docker installed, plus the tag-and-push commands for both
  registries (GHCR via gh-token login, Docker Hub via interactive
  login). Status section updated.

- `README.md`: the `For Docker deployments` placeholder added in
  PR-B is replaced with a concrete `docker run` example pointing
  at `steggl/openclaw-turbocharger:0.1.0-alpha.0`.

- `CHANGELOG.md`: new `Distribution` section in the v0.1.0-alpha.0
  entry documents both npm and Docker delivery: scope, registry
  paths, dist-tags, and runtime image properties.

## Verification

Local smoke test on Apple Silicon with OrbStack:

- `docker build .`: 14.7s (cold), all 9 builder steps + 5 runtime
  steps clean.
- Container reaches `Up 3 seconds` status without crash.
- Server logs structured JSON on startup:
  `{"event":"listen","port":11435,"downstream":"..."}`.
- `nc -zv localhost 11435` reports
  `Connection to localhost port 11435 [tcp/*] succeeded!`.

CI smoke test (the `docker-smoke` job in this PR's CI run): see
the green check.

## Out of scope (this PR)

- Tag, GitHub Release, npm publish, Docker push — happens after
  this PR lands as the manual release sequence in
  `docs/RELEASING.md`.
- Auto-publish via GitHub Actions — deferred per scope decision.
- Healthcheck directive — no health endpoint exists yet (would
  need `/healthz` in `src/server.ts` first); skipped rather than
  faked.
- OpenClaw plugin SDK integration — tracked as #22.