### PR TITLE
release: promote CHANGELOG date to 2026-05-02 for v0.1.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-## [0.1.0-alpha.0] — 2026-04-30
+## [0.1.0-alpha.0] — 2026-05-02
 
 First published alpha release. All 15 MVP issues from `PROJECT_BRIEF.md`
 §10 are merged.


### PR DESCRIPTION
Last commit before v0.1.0-alpha.0 is tagged.

The CHANGELOG entry was authored on 2026-04-30 in PR-A. The actual
release ships today (2026-05-02). This one-line change aligns the
date in the published CHANGELOG with the tag/Release/npm-publish
date so anyone reading the released artifact sees the correct
timestamp.

## Verification

- `git diff CHANGELOG.md` shows exactly one line changed.
- `pnpm check` green locally (315 passed | 3 todo, build 53.55 kB).

## Why a PR for one line

`main` is branch-protected. A direct push for one character would
bypass the protection. Following the same PR discipline the rest of
issue #15 used keeps the history honest.

## Next

After merge: tag `v0.1.0-alpha.0`, GitHub Release, `pnpm publish
--tag alpha`, Docker build/push.