### PR TITLE
fix(critic): resolve BCP-47 locale prefix in refusalDetector (#18)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1565,3 +1565,93 @@ verdict.confidence >= threshold)`. A pass verdict never triggers
   default), ADR-0023 (card structure), ADR-0024 (the static
   configuration surface this layer sits on top of), brief
   §5 ("Per-chat override"), brief §8 ("no silent fallbacks").
+
+## ADR-0026: Locale resolution helper for BCP-47 prefix matching
+
+**Status:** accepted (issue #18)
+
+**Context.** The hard-signal `refusalDetector` (`src/critic/hard-signals.ts`)
+was looking up `REFUSAL_PATTERNS[input.locale]` directly, which matches
+only when the locale string is exactly one of the keys (`'en'` or `'de'`).
+Real-world clients send BCP-47 tags with region subtags
+(`Accept-Language: de-DE`, `de-AT`) and occasionally the legacy
+underscore form (`de_DE`); none of these matched the `de` bucket. The
+detector then fell back to English-only patterns, missing
+German-language refusals such as "Tut mir leid, ich kann dir nicht
+helfen". The bug was found while writing the German integration test
+for ADR-0023's transparency card and deferred to issue #18.
+
+The transparency layer (`src/transparency/banner.ts`,
+`src/transparency/card.ts`) had already solved the same problem with
+hand-rolled `resolveBannerLocale` and `resolveCardLocale` helpers. Both
+hard-code the `de` mapping and predate this ADR.
+
+**Decision.** Introduce a generic helper at `src/locale.ts`:
+
+```ts
+resolveLocale<L extends string>(
+  input: string | undefined,
+  allowed: readonly L[],
+  fallback: L,
+): L
+```
+
+The helper accepts any user-supplied locale string, lowercases it,
+and matches it against `allowed` using either exact match or a
+prefix-with-separator match (`-` or `_`). The longest matching
+prefix wins, so a future caller can list `['pt-BR', 'pt']` and have
+the regional bucket take precedence over the bare-language bucket
+when the input matches it. With the current `['en', 'de']` callers,
+the longest-prefix tie-breaking is dormant but free.
+
+Use the helper in `refusalDetector` only. The transparency-layer
+resolvers stay where they are.
+
+**Consequences.**
+
+- `Accept-Language: de-DE` (and `de_DE`, `DE`, `de-CH`, etc.) now
+  resolves to the German pattern bucket, restoring the locale-keyed
+  detection that was originally intended.
+- The English fallback inside `refusalDetector` (always trying
+  English patterns in addition to the resolved locale) is preserved.
+  Resolution determines which bucket is "primary"; the English
+  fallback is unaffected.
+- New locale-keyed tables anywhere in `src/critic/` should reach for
+  `resolveLocale`, not write a fresh resolver.
+- Adding a new locale to the refusal patterns requires two changes:
+  add the bucket to `REFUSAL_PATTERNS`, add the key to
+  `REFUSAL_LOCALES`. The `as const` ensures TypeScript fails the
+  build if the two go out of sync.
+
+**Alternatives considered.**
+
+1. _Inline the prefix logic in `refusalDetector`._ Smaller diff but
+   leaves the fix non-reusable. The next locale-keyed lookup in
+   `src/critic/` would re-encounter the same bug.
+2. _Migrate `resolveBannerLocale` and `resolveCardLocale` to the new
+   helper in the same PR._ Tempting (DRY), but the transparency
+   resolvers are not buggy and their return types carry narrow
+   unions (`BannerLocale`, `CardLocale`) that a generic helper
+   would broaden. Out of scope for a bug-fix PR; tracked as a
+   follow-up if a third locale-keyed table appears or one of the
+   transparency resolvers gains a real bug.
+3. _Use `Intl.Locale` (Node ≥ 14)._ Heavier and would still leave the
+   bucket-mapping problem (`new Intl.Locale('de-DE').language === 'de'`
+   gives the language tag, but the table lookup still has to choose
+   which bucket to use). The chosen helper does both steps in one
+   call.
+
+**Out of scope.**
+
+- Adding new locales to `REFUSAL_PATTERNS` (the bug is about
+  resolving the existing two consistently).
+- Migrating the transparency-layer resolvers (alternative 2 above).
+- The LLM critic's locale handling — that runs through a separate
+  code path with its own locale-keyed prompts (see ADR-0007).
+
+**References.**
+
+- Issue #18 (the bug report)
+- ADR-0023 (transparency card, where the bug was first noticed)
+- `src/transparency/banner.ts` — `resolveBannerLocale`, the local
+  resolver that does not migrate in this PR

--- a/src/critic/hard-signals.ts
+++ b/src/critic/hard-signals.ts
@@ -18,6 +18,7 @@
 //   - Weight application: issue #5.
 
 import type { DetectorInput, HardSignalDetector, Signal } from '../types.js';
+import { resolveLocale } from '../locale.js';
 
 // ---------------------------------------------------------------------------
 // Refusal
@@ -71,9 +72,14 @@ const REFUSAL_PATTERNS: Readonly<Record<string, readonly RefusalPattern[]>> = {
 };
 
 const DEFAULT_LOCALE = 'en';
+const REFUSAL_LOCALES = ['en', 'de'] as const;
 
 export const refusalDetector: HardSignalDetector = (input) => {
-  const locale = input.locale ?? DEFAULT_LOCALE;
+  // Resolve the request locale to one of the buckets we actually have
+  // patterns for. Without this resolver, `Accept-Language: de-DE` would
+  // miss the German bucket and fall through to English-only patterns.
+  // See ADR-0026 and issue #18.
+  const locale = resolveLocale(input.locale, REFUSAL_LOCALES, DEFAULT_LOCALE);
   const primary = REFUSAL_PATTERNS[locale] ?? REFUSAL_PATTERNS[DEFAULT_LOCALE] ?? [];
   // Also try English patterns as a fallback — non-English interactions
   // frequently surface English refusal phrasing from providers whose

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,0 +1,55 @@
+// Locale resolution helper. Resolves user-supplied locale strings (which
+// may carry BCP-47 region/script subtags or use the underscore convention,
+// e.g. `de-DE`, `de_DE`) down to the bucket that the caller's locale-keyed
+// table actually contains.
+//
+// The transparency layer has its own resolvers (`resolveBannerLocale`,
+// `resolveCardLocale`) that pre-date this helper and use a hard-coded
+// `de` mapping. They are intentionally not migrated here — see ADR-0026
+// for the scope decision. New locale-keyed tables should reach for this
+// helper instead of growing another bespoke resolver.
+//
+// Algorithm: case-insensitive prefix match against the entries of
+// `allowed`. The longest-prefix winner is chosen so a future caller can
+// list `pt-BR` ahead of `pt` and have Brazilian Portuguese take
+// precedence over a Portuguese fallback when the input is `pt-BR-x-foo`.
+// In practice the current callers only declare bare language codes, so
+// the longest-prefix tie-breaking is dormant but free.
+//
+// Returns `fallback` when no entry of `allowed` is a prefix of the input.
+
+/**
+ * Resolve a user-supplied locale string against a closed list of buckets.
+ *
+ * @param input    Locale string from the request, e.g. `'de-DE'`,
+ *                 `'de_DE'`, `'DE'`, `'fr-CA'`, `''`, or `undefined`.
+ * @param allowed  The buckets the caller actually has data for, e.g.
+ *                 `['en', 'de'] as const`.
+ * @param fallback The bucket to return when no entry of `allowed` is a
+ *                 prefix of `input`.
+ *
+ * @returns One of the entries of `allowed`, or `fallback` if nothing
+ *          matched.
+ */
+export function resolveLocale<L extends string>(
+  input: string | undefined,
+  allowed: readonly L[],
+  fallback: L,
+): L {
+  if (input === undefined || input.length === 0) return fallback;
+  const lower = input.toLowerCase();
+
+  // Iterate longest-first so a caller listing `['pt-BR', 'pt']` would
+  // match `'pt-BR-x-foo'` against `'pt-BR'` rather than `'pt'`. With
+  // the current callers (`['en', 'de']`) the order is irrelevant.
+  const sorted = [...allowed].sort((a, b) => b.length - a.length);
+
+  for (const candidate of sorted) {
+    const cl = candidate.toLowerCase();
+    if (lower === cl || lower.startsWith(`${cl}-`) || lower.startsWith(`${cl}_`)) {
+      return candidate;
+    }
+  }
+
+  return fallback;
+}

--- a/test/hard-signals.test.ts
+++ b/test/hard-signals.test.ts
@@ -93,6 +93,54 @@ describe('refusalDetector', () => {
     expect(signal).not.toBeNull();
   });
 
+  // Issue #18: BCP-47 region subtags must resolve to the bare-language
+  // bucket. Before the fix, `locale: 'de-DE'` missed the `de` patterns
+  // entirely and fell back to English, so a German-only refusal phrase
+  // went undetected.
+  it('resolves de-DE to the German bucket and detects a German-only refusal', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'Tut mir leid, aber ich kann dir nicht helfen.',
+        locale: 'de-DE',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.category).toBe('refusal');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('resolves de_DE (underscore form) to the German bucket', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'Leider, aber ich kann dir nicht helfen.',
+        locale: 'de_DE',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.category).toBe('refusal');
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('treats locale matching as case-insensitive (DE-de resolves to de)', () => {
+    const signal = refusalDetector(
+      makeInput({
+        response: 'Leider, aber ich kann dir nicht helfen.',
+        locale: 'DE-de',
+      }),
+    );
+    expect(signal).not.toBeNull();
+    expect(signal?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('falls back to English when an unknown BCP-47 locale carries a region subtag', () => {
+    // fr-FR was not in REFUSAL_LOCALES at the time of writing; behaviour
+    // should mirror bare 'fr', not silently match some unrelated bucket.
+    const signal = refusalDetector(
+      makeInput({ response: "I'm sorry, but I cannot help with that.", locale: 'fr-FR' }),
+    );
+    expect(signal).not.toBeNull();
+  });
+
   it('reports the highest-confidence match when multiple patterns fire', () => {
     const signal = refusalDetector(
       makeInput({

--- a/test/locale.test.ts
+++ b/test/locale.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocale } from '../src/locale.js';
+
+const ALLOWED = ['en', 'de'] as const;
+
+describe('resolveLocale', () => {
+  it('returns the bare match when input equals an allowed entry', () => {
+    expect(resolveLocale('en', ALLOWED, 'en')).toBe('en');
+    expect(resolveLocale('de', ALLOWED, 'en')).toBe('de');
+  });
+
+  it('matches BCP-47 region subtags via the dash separator', () => {
+    expect(resolveLocale('de-DE', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('de-AT', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('de-CH', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('en-US', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('matches Java-style locale tags via the underscore separator', () => {
+    expect(resolveLocale('de_DE', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('en_US', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('is case-insensitive on both sides', () => {
+    expect(resolveLocale('DE', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('De-De', ALLOWED, 'en')).toBe('de');
+    expect(resolveLocale('EN-us', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('returns the fallback when input does not match any entry', () => {
+    expect(resolveLocale('fr', ALLOWED, 'en')).toBe('en');
+    expect(resolveLocale('fr-FR', ALLOWED, 'en')).toBe('en');
+    expect(resolveLocale('zh-CN', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('returns the fallback for undefined or empty input', () => {
+    expect(resolveLocale(undefined, ALLOWED, 'en')).toBe('en');
+    expect(resolveLocale('', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('does not match when the prefix is followed by other letters', () => {
+    // 'de' is in allowed; 'denmark' should NOT resolve to 'de' because
+    // 'denmark' is not a BCP-47 extension of the language tag 'de'.
+    expect(resolveLocale('denmark', ALLOWED, 'en')).toBe('en');
+    // Same logic with mixed case to confirm the boundary check is
+    // structural, not casing-sensitive.
+    expect(resolveLocale('DEnmark', ALLOWED, 'en')).toBe('en');
+  });
+
+  it('respects longest-prefix precedence when buckets overlap', () => {
+    // Synthetic: caller declares both a regional bucket and the bare
+    // language. The regional one should win when the input matches it.
+    const overlap = ['pt-BR', 'pt'] as const;
+    expect(resolveLocale('pt-BR', overlap, 'pt')).toBe('pt-BR');
+    expect(resolveLocale('pt-BR-x-foo', overlap, 'pt')).toBe('pt-BR');
+    expect(resolveLocale('pt-PT', overlap, 'pt')).toBe('pt');
+    expect(resolveLocale('pt', overlap, 'pt')).toBe('pt');
+  });
+});


### PR DESCRIPTION
Closes #18.

## Cause

`refusalDetector` looked up `REFUSAL_PATTERNS[input.locale]`
directly. With `Accept-Language: de-DE` (or any other BCP-47 tag,
or the legacy underscore form `de_DE`), this missed the German
bucket and fell back to English-only patterns. German-only
refusals like "Tut mir leid, ich kann dir nicht helfen" went
undetected.

## Fix

New generic helper at `src/locale.ts`:

```ts
resolveLocale<L extends string>(input, allowed, fallback): L
```

Routes the bucket lookup in `refusalDetector` through it. Helper
handles dash-form (`de-DE`), underscore-form (`de_DE`),
case-insensitivity (`DE-de`), and longest-prefix precedence (for
forward-compat with regional buckets like `pt-BR` vs `pt`).
Boundary check: `denmark` does NOT resolve to `de`.

## Scope (deliberately minimal)

- Helper used in `refusalDetector` only.
- `resolveBannerLocale` / `resolveCardLocale` in
  `src/transparency/` are unchanged. They are not buggy; their
  return types carry narrow unions (`BannerLocale`, `CardLocale`)
  that a generic helper would broaden. Migration deferred per
  ADR-0026 alternative 2.
- No new locales added to `REFUSAL_PATTERNS`. The bug is about
  resolving the existing two consistently.
- LLM critic's locale handling runs through a separate code path
  (ADR-0007) and is unaffected.

## Tests

- `test/locale.test.ts` (new): 8 direct tests for the helper —
  exact match, dash form, underscore form, case-insensitivity,
  unknown locales, undefined/empty inputs, prefix-boundary guard,
  longest-prefix precedence.
- `test/hard-signals.test.ts` (extended): 4 new integration tests
  — `de-DE`, `de_DE`, `DE-de` resolve to the German bucket and
  detect a German-only refusal at high confidence; `fr-FR` falls
  back to English consistently with the existing `fr` test.

## Verification

`pnpm check` green locally — 327 passed | 3 todo (vs 315 before
this PR), build clean (54.06 kB / +510 B for the helper logic),
no Prettier drift.

## Related

- Issue #18 (bug report)
- ADR-0023 (transparency card, where the bug was first noticed)
- ADR-0026 (this PR's design decision)