### PR TITLE
docs(examples): refresh config examples to match v0.1.0-alpha.0 schema

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ Both demonstrate `answerMode: 'single'` (reactive escalation) with:
   endpoint URL. The block is ignored unless `answerMode: 'chorus'`.
 - Transparency in `banner` mode (the technical default is `silent`).
 
-## What the examples do *not* show
+## What the examples do _not_ show
 
 ### `llmCritic` is absent
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,67 @@
+# Configuration examples
+
+Two ready-to-adapt examples of an `openclaw-turbocharger` config:
+
+- [`standalone-config.example.yaml`](./standalone-config.example.yaml) — YAML
+  format, with inline comments explaining each field.
+- [`openclaw-config.example.json`](./openclaw-config.example.json) — JSON
+  format, same content as the YAML example minus the comments
+  (JSON has no comment syntax).
+
+Both are **schema-conformant** against
+[`TurbochargerConfigSchema`](../src/config/schema.ts) as of
+v0.1.0-alpha.0. Operators can copy either file, adapt the values,
+and load it via the `TURBOCHARGER_CONFIG` environment variable:
+
+```bash
+TURBOCHARGER_CONFIG=/path/to/config.yaml openclaw-turbocharger
+```
+
+Field-by-field reference: [`docs/CONFIGURATION.md`](../docs/CONFIGURATION.md).
+
+## What the examples show
+
+Both demonstrate `answerMode: 'single'` (reactive escalation) with:
+
+- An orchestrator threshold of `0.6` and a grey band of `[0.30, 0.60]`.
+- All six signal categories at weight `1.0` (neutral; tune as needed).
+- A ladder-strategy escalation across four models (one local, three
+  hosted), `maxDepth: 2`.
+- A chorus block included for completeness, with a placeholder
+  endpoint URL. The block is ignored unless `answerMode: 'chorus'`.
+- Transparency in `banner` mode (the technical default is `silent`).
+
+## What the examples do *not* show
+
+### `llmCritic` is absent
+
+The orchestrator supports an optional LLM critic for tie-breaking
+inside the grey band, but it cannot be configured purely from a
+static config file. The loader populates the static fields
+(`baseUrl`, `model`, `apiKey`, `timeoutMs`, `budgetUsd`, `pricing`),
+but the critic also needs a `run` callable that actually calls the
+LLM and parses the verdict — this has to be assembled in code and
+merged onto the loaded config before passing it to `startServer`.
+
+The YAML example shows the static-field shape as a commented block
+for reference. The JSON example omits it entirely (JSON has no
+comment syntax). See `docs/CONFIGURATION.md` for the in-code
+wiring pattern.
+
+### `chorus` mode
+
+Both examples use `answerMode: 'single'`. To use chorus mode, set
+`answerMode: 'chorus'` and replace the placeholder
+`chorus.endpoint` with a real chorus-server URL. Per ADR-0021
+chorus is an orthogonal answer mode, not a stage of the
+single-mode pipeline; the orchestrator and escalation blocks are
+ignored in chorus mode.
+
+## Status: validated
+
+These examples were stale prior to the v0.1.0-alpha.0 release —
+they used snake_case field names and a `turbocharger:` wrapper that
+predated the Zod schema in `src/config/schema.ts`. They have been
+refreshed to match the live schema and are now part of the
+schema's contract: changes to the schema that break these
+examples will require a corresponding update here.

--- a/examples/openclaw-config.example.json
+++ b/examples/openclaw-config.example.json
@@ -1,43 +1,35 @@
 {
-  "_note": "ILLUSTRATIVE example config — JSON variant of examples/standalone-config.example.yaml. Mirrors the type surface in src/types.ts but is not yet validated against a live schema (schema lands with issue #11). See docs/CONFIGURATION.md for the field-by-field reference. Transparency mode is set to 'banner' here to demonstrate the opt-in deployment shape; the technical default is 'silent'.",
-  "turbocharger": {
-    "port": 11435,
-    "downstream_base_url": "http://localhost:11434/v1",
-    "answer_mode": "single",
-    "orchestrator": {
-      "threshold": 0.6,
-      "grey_band": [0.3, 0.6],
-      "weights": {
-        "refusal": 1.0,
-        "truncation": 1.0,
-        "repetition": 1.0,
-        "empty": 1.0,
-        "tool_error": 1.0,
-        "syntax_error": 1.0
-      },
-      "llm_critic": {
-        "base_url": "http://localhost:11434/v1",
-        "model": "qwen2.5:7b",
-        "budget_usd": 0.01
-      }
-    },
-    "escalation": {
-      "mode": "ladder",
-      "ladder": [
-        "ollama/qwen2.5:7b",
-        "anthropic/claude-haiku-4-5",
-        "anthropic/claude-sonnet-4-6",
-        "anthropic/claude-opus-4-7"
-      ],
-      "max_model": "anthropic/claude-opus-4-7",
-      "max_depth": 2
-    },
-    "chorus": {
-      "endpoint": null,
-      "timeout_ms": 90000
-    },
-    "transparency": {
-      "mode": "banner"
+  "port": 11435,
+  "downstreamBaseUrl": "http://localhost:11434/v1",
+  "answerMode": "single",
+  "orchestrator": {
+    "threshold": 0.6,
+    "greyBand": [0.3, 0.6],
+    "weights": {
+      "refusal": 1.0,
+      "truncation": 1.0,
+      "repetition": 1.0,
+      "empty": 1.0,
+      "tool_error": 1.0,
+      "syntax_error": 1.0
     }
+  },
+  "escalation": {
+    "mode": "ladder",
+    "ladder": [
+      "qwen2.5:7b",
+      "anthropic/claude-haiku-4-5",
+      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-opus-4-7"
+    ],
+    "maxModel": "anthropic/claude-opus-4-7",
+    "maxDepth": 2
+  },
+  "chorus": {
+    "endpoint": "https://chorus.example.com/v1",
+    "timeoutMs": 90000
+  },
+  "transparency": {
+    "mode": "banner"
   }
 }

--- a/examples/standalone-config.example.yaml
+++ b/examples/standalone-config.example.yaml
@@ -1,70 +1,111 @@
 # openclaw-turbocharger — standalone config example
 #
-# Status: ILLUSTRATIVE. This example mirrors the type surface in
-# src/types.ts but is not yet validated against a live schema (schema
-# lands with issue #11). Keys and types may still change before
-# v0.1.0-alpha. See docs/CONFIGURATION.md for the field-by-field
-# reference.
+# Status: VALIDATED. This example is schema-conformant against
+# `TurbochargerConfigSchema` in `src/config/schema.ts` as of
+# v0.1.0-alpha.0. Operators can copy this file, adapt the values,
+# and load it via `TURBOCHARGER_CONFIG=/path/to/config.yaml`. See
+# docs/CONFIGURATION.md for the field-by-field reference.
+#
+# Top level is flat: AppConfig fields (port, downstreamBaseUrl,
+# downstreamApiKey) sit alongside the optional sub-configs
+# (orchestrator, escalation, chorus, transparency, answerMode).
+# Field names are camelCase.
 
-turbocharger:
-  port: 11435
-  downstream_base_url: http://localhost:11434/v1
+port: 11435
+downstreamBaseUrl: http://localhost:11434/v1
 
-  # Top-level paradigm: 'single' (default) for reactive escalation, or
-  # 'chorus' for direct dispatch to a multi-model consensus endpoint.
-  # Per ADR-0021 these are orthogonal answer modes, not stages of the
-  # same process.
-  answer_mode: single
+# downstreamApiKey: sk-...                 # optional, omit for local providers
 
-  # Adequacy critic (single mode). Skipped entirely in chorus mode.
-  orchestrator:
-    threshold: 0.6
-    grey_band: [0.30, 0.60]
-    weights:
-      refusal: 1.0
-      truncation: 1.0
-      repetition: 1.0
-      empty: 1.0
-      tool_error: 1.0
-      syntax_error: 1.0
-    llm_critic:
-      base_url: http://localhost:11434/v1
-      model: qwen2.5:7b
-      budget_usd: 0.01
+# Top-level paradigm: 'single' (default) for reactive escalation, or
+# 'chorus' for direct dispatch to a multi-model consensus endpoint.
+# Per ADR-0021 these are orthogonal answer modes, not stages of the
+# same process. When 'chorus' is set, the chorus block below is
+# required.
+answerMode: single
 
-  # Escalation strategy (single mode + escalate decision). Per
-  # ADR-0021, chorus is no longer an escalation mode — it lives
-  # under its own top-level 'chorus' section below.
-  escalation:
-    # ladder | max
-    mode: ladder
+# Adequacy critic for the 'single' answer mode. Skipped entirely
+# when answerMode is 'chorus'.
+orchestrator:
+  # Aggregate score above which an escalation fires. Hard signals
+  # are combined via noisy-OR, so 0.6 means roughly "any single
+  # high-confidence signal escalates, two medium signals escalate".
+  threshold: 0.6
 
-    # Ordered chain used by the 'ladder' strategy. Each step is a
-    # model id the downstream target understands.
-    ladder:
-      - ollama/qwen2.5:7b
-      - anthropic/claude-haiku-4-5
-      - anthropic/claude-sonnet-4-6
-      - anthropic/claude-opus-4-7
+  # Score range where the LLM critic (if configured in code) is
+  # consulted for tie-breaking. Below the lower bound the
+  # orchestrator passes; above the upper bound it escalates;
+  # in between it asks the LLM critic. With no llmCritic the
+  # grey band still applies — the orchestrator just treats the
+  # uncertain range as "pass" by default.
+  greyBand: [0.30, 0.60]
 
-    # Target used by the 'max' strategy (single jump). Required
-    # when mode is 'max'; ignored in 'ladder' mode.
-    max_model: anthropic/claude-opus-4-7
+  # Per-category weights applied before noisy-OR aggregation.
+  # All six categories are required. Values must be in [0, 1].
+  # Note: the keys here are SignalCategory values (snake_case in
+  # the runtime types), not config field names — they stay as-is.
+  weights:
+    refusal: 1.0
+    truncation: 1.0
+    repetition: 1.0
+    empty: 1.0
+    tool_error: 1.0
+    syntax_error: 1.0
 
-    # Maximum consecutive escalations per request (prevents runaway
-    # costs). Per ADR-0018, 2 is the recommended default.
-    max_depth: 2
+  # Optional LLM critic. Cannot be configured purely from YAML —
+  # the loader can populate the static fields below, but the
+  # actual `run` callable that calls the LLM has to be assembled
+  # in code and merged onto the loaded config before passing it
+  # to startServer. See docs/CONFIGURATION.md for the in-code
+  # wiring pattern.
+  #
+  # llmCritic:
+  #   baseUrl: http://localhost:11434/v1
+  #   model: qwen2.5:7b
+  #   apiKey: sk-...                       # optional
+  #   timeoutMs: 30000                     # optional
+  #   budgetUsd: 0.01                      # optional
+  #   pricing:                             # optional
+  #     promptUsdPerKToken: 0.0
+  #     completionUsdPerKToken: 0.0
 
-  # Chorus configuration (chorus mode only). Active when
-  # answer_mode is 'chorus'; ignored otherwise. Per ADR-0020 the
-  # dispatch is hard-fail — no silent fallback to single mode.
-  chorus:
-    endpoint: null # set to a chorus endpoint URL, e.g. openclaw-chorus
-    timeout_ms: 90000
+# Escalation strategy for the 'single' answer mode. Active when
+# the orchestrator returns 'escalate'. Per ADR-0021, chorus is
+# not an escalation mode — it lives under its own top-level
+# 'chorus' section below.
+escalation:
+  # 'ladder' walks the chain step-by-step (one re-query per
+  # escalation), 'max' jumps directly to the maxModel.
+  mode: ladder
 
-  # Transparency layer. The technical default is silent — set
-  # mode: banner below to opt in to user-visible escalation
-  # annotations. See ADR-0022.
-  transparency:
-    # banner | silent (card lands with issue #10)
-    mode: banner
+  # Ordered chain used by the 'ladder' strategy. Each entry is a
+  # model id the downstream target understands.
+  ladder:
+    - qwen2.5:7b
+    - anthropic/claude-haiku-4-5
+    - anthropic/claude-sonnet-4-6
+    - anthropic/claude-opus-4-7
+
+  # Target used by the 'max' strategy (single jump). Required
+  # when mode is 'max'; ignored when mode is 'ladder'.
+  maxModel: anthropic/claude-opus-4-7
+
+  # Maximum consecutive escalations per request. Prevents runaway
+  # costs if the critic keeps firing. Per ADR-0018, 2 is the
+  # recommended default.
+  maxDepth: 2
+
+# Chorus configuration. Active when answerMode is 'chorus';
+# ignored otherwise. Per ADR-0020 the dispatch is hard-fail —
+# no silent fallback to single mode if the endpoint is down.
+chorus:
+  endpoint: https://chorus.example.com/v1     # required when answerMode is 'chorus'
+  timeoutMs: 90000                            # optional, default unset
+
+# Transparency layer. The technical default is 'silent' — set
+# mode below to opt in to user-visible escalation annotations.
+# 'banner' prepends a one-line note. 'card' injects a structured
+# Markdown block describing the decision. Per ADR-0023 the card
+# is locale-aware (en/de) and only injects when escalation
+# depth > 0.
+transparency:
+  mode: banner                                # banner | silent | card

--- a/examples/standalone-config.example.yaml
+++ b/examples/standalone-config.example.yaml
@@ -98,8 +98,8 @@ escalation:
 # ignored otherwise. Per ADR-0020 the dispatch is hard-fail —
 # no silent fallback to single mode if the endpoint is down.
 chorus:
-  endpoint: https://chorus.example.com/v1     # required when answerMode is 'chorus'
-  timeoutMs: 90000                            # optional, default unset
+  endpoint: https://chorus.example.com/v1 # required when answerMode is 'chorus'
+  timeoutMs: 90000 # optional, default unset
 
 # Transparency layer. The technical default is 'silent' — set
 # mode below to opt in to user-visible escalation annotations.
@@ -108,4 +108,4 @@ chorus:
 # is locale-aware (en/de) and only injects when escalation
 # depth > 0.
 transparency:
-  mode: banner                                # banner | silent | card
+  mode: banner # banner | silent | card


### PR DESCRIPTION
The two example config files predated PR-#11's Zod schema. They
were marked `ILLUSTRATIVE`, used snake_case + a `turbocharger:`
wrapper, and would have failed schema validation if anyone copied
them as-is.

## What changed

- **Drop the `turbocharger:` wrapper.** Live schema is flat at top
  level.
- **snake_case → camelCase** throughout (`downstreamBaseUrl`,
  `greyBand`, `maxDepth`, etc.). The keys inside
  `orchestrator.weights` stay snake_case because those are
  `SignalCategory` runtime values, not config field names.
- **`llmCritic` removed from the executable parts.** Loader can't
  populate it from YAML — needs a `run` callable assembled in
  code. YAML keeps a commented-out reference block; JSON omits
  entirely.
- **Real chorus URL** instead of `null` placeholder
  (schema requires fully-qualified http(s)).
- **`_note` removed from JSON.** Top-level `.strict()` would have
  rejected it.
- **Status: ILLUSTRATIVE → VALIDATED.** The examples are now part
  of the schema's contract.
- **New `examples/README.md`** explaining both files, the
  `llmCritic` absence, and what's deliberately not shown.

## Verification

`pnpm check` green. Both files load without validation errors:

\`\`\`bash
TURBOCHARGER_CONFIG=examples/standalone-config.example.yaml node dist/server.js
TURBOCHARGER_CONFIG=examples/openclaw-config.example.json  node dist/server.js
\`\`\`

Both print `event:listen` and serve.

## Out of scope

- `docs/CONFIGURATION.md` field-by-field reference. May still
  reference snake_case names; follow-up PR if so.
- Adding new examples (e.g., a minimal-config variant). One
  full-shape example per format is enough for the first pass.