### PR TITLE
chore(plugin): pre-publish setup — files fix + CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,39 @@ jobs:
       - name: Build
         run: pnpm build
 
+  plugin:
+    name: Plugin tests (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+          cache-dependency-path: plugin/pnpm-lock.yaml
+
+      - name: Install plugin dependencies
+        working-directory: plugin
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        working-directory: plugin
+        run: pnpm typecheck
+
+      - name: Test
+        working-directory: plugin
+        run: pnpm test
+
   docker-smoke:
     name: Docker smoke test
     runs-on: ubuntu-latest

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "main": "./index.ts",
   "files": [
+    "README.md",
     "index.ts",
     "openclaw.plugin.json",
-    "README.md"
+    "wizard.ts"
   ],
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
Two pre-release housekeeping changes that unblock the plugin's first
npm publish (issue #32 PR-C, next).

## 1. `plugin/package.json` files-array fix

PR-B extracted helpers into `plugin/wizard.ts` but did not update the
package.json `files` array. `pnpm pack --dry-run` confirmed the bug:
the tarball would have shipped without `wizard.ts`, breaking the
runtime import `from './wizard.js'` in `index.ts`.

Before:
Tarball Contents
index.ts
openclaw.plugin.json
package.json
README.md

After:
Tarball Contents
index.ts
openclaw.plugin.json
package.json
README.md
wizard.ts

## 2. `.github/workflows/ci.yml` plugin job

Add a separate `plugin` job between the existing `ci` and
`docker-smoke` jobs. The plugin lives in `plugin/` as a standalone
npm package with its own `pnpm-lock.yaml`, so it needs its own
install + typecheck + test cycle.

Using a **separate job** (rather than an extra step in the existing
`ci` job) keeps the cache key clean (`cache-dependency-path:
plugin/pnpm-lock.yaml`) and surfaces plugin-only failures clearly in
the GitHub Actions UI.

The plugin job mirrors the `ci` job's structure (checkout, pnpm
setup, node 22, install, typecheck, test) but with
`working-directory: plugin` and no lint / format-check / build —
those are root-level concerns; the plugin has no build step
(TypeScript source ships as-is, OpenClaw loads via jiti).

## Verification

Local before push:
plugin/$ pnpm pack --dry-run    # 5 files, wizard.ts included
plugin/$ pnpm typecheck         # clean
plugin/$ pnpm test              # 15 passing
root/$   pnpm format:check      # clean

CI here is the real test — the `plugin` job runs for the first
time in this PR.

## Why both in one PR

Both changes are pre-publish housekeeping with the same goal:
make the plugin safely publishable. Without the files fix, the
published plugin fails at runtime; without the CI job, future
plugin changes could regress without anyone noticing. Splitting
them adds review overhead without clarity.

## Refs

- #32 PR-C (next — actual npm publish)
- #32 (parent issue)