### PR TITLE
chore(docs): post-release hygiene — gitignore tgz, README status update

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,13 @@ The MVP is complete. Post-v0.1.0-alpha work is tracked in the issue
 tracker on GitHub. Notable items:
 
 - **#22 `plugin-sdk`** — research phase complete (ADR-0027); the
-  Provider plugin scaffold lives in [`plugin/`](./plugin/) on
-  `main` and is tracked as [issue #32](https://github.com/Steggl/openclaw-turbocharger/issues/32).
-  Publish to npm (`@steggl/openclaw-turbocharger-provider`) and
-  end-to-end validation against a real OpenClaw process are still
-  pending. See [Use with OpenClaw](#use-with-openclaw) below for the
-  current integration paths.
+  Provider plugin is published as
+  [`@steggl/openclaw-turbocharger-provider`](https://www.npmjs.com/package/@steggl/openclaw-turbocharger-provider)
+  on npm (v0.1.0-alpha.0, tagged `plugin/v0.1.0-alpha.0`).
+  End-to-end validation against a real OpenClaw process is still
+  pending; tracked at
+  [issue #32](https://github.com/Steggl/openclaw-turbocharger/issues/32)
+  (Sub-Test 4). See [Use with OpenClaw](#use-with-openclaw) below.
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the v0.1.0-alpha.0 release
 notes and [`docs/RELEASING.md`](./docs/RELEASING.md) for how releases
@@ -263,7 +264,7 @@ HTTP endpoint; the reactive-escalation logic runs transparently, and
 the sidecar's `X-Turbocharger-*` response headers describe what
 happened.
 
-### Native plugin (in development)
+### Native plugin (alpha)
 
 ```bash
 openclaw plugins install npm:@steggl/openclaw-turbocharger-provider
@@ -276,9 +277,12 @@ comma-separated list of model IDs. See
 [`plugin/README.md`](./plugin/README.md) for full configuration
 details.
 
-> **Status:** the plugin scaffold is in `main` but not yet published
-> to npm. Track publish status at
-> [issue #32](https://github.com/Steggl/openclaw-turbocharger/issues/32).
+> **Status:** the plugin is published as
+> [`@steggl/openclaw-turbocharger-provider@0.1.0-alpha.0`](https://www.npmjs.com/package/@steggl/openclaw-turbocharger-provider)
+> on npm. End-to-end validation against a real OpenClaw process is
+> still pending; tracked at
+> [issue #32](https://github.com/Steggl/openclaw-turbocharger/issues/32)
+> (Sub-Test 4).
 
 ### Manual configuration (works today)
 

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 coverage/
+*.tgz
 *.tsbuildinfo


### PR DESCRIPTION
Three small post-release follow-ups after `@steggl/openclaw-turbocharger-provider@0.1.0-alpha.0` went live on npm.

## 1. `plugin/.gitignore`: add `*.tgz`

`pnpm pack` produces a `.tgz` file in the plugin directory. During
the actual publish session, pnpm refused to publish from an unclean
tree because that file was untracked. Ignoring `*.tgz` prevents the
issue from recurring.

## 2. README.md "Use with OpenClaw" section update

- Section heading: `### Native plugin (in development)` → `### Native plugin (alpha)`
- Status blockquote: rewritten from "not yet published, track at #32" to "published as v0.1.0-alpha.0, e2e validation still pending at #32 Sub-Test 4"

Both reflect the real status of the plugin now.

## 3. README.md "What's next" #22 entry

The #22 entry in the roadmap was last updated in PR #34 (when the
scaffold first landed). Now updated again to match the
published-on-npm status. Both this entry and the "Use with OpenClaw"
blockquote stay in lockstep.

## Diff

`README.md | 24 +-` and `plugin/.gitignore | 1 +` — small, surgical.

## What this doesn't address (next PR)

Item 3 from today's follow-up list — the broader docs refresh covering
About description, CONTRIBUTING.md, COMPARISON.md, CONFIGURATION.md —
is deferred to its own PR. That one needs ~60-90 min and a fresh
review cycle.

## Refs

- #32 (still open for Sub-Test 4)